### PR TITLE
refactor: clearer name for ams_auth_key

### DIFF
--- a/federation-registry-backend-rabbitmq-agent/app.js
+++ b/federation-registry-backend-rabbitmq-agent/app.js
@@ -36,7 +36,7 @@ const options = {
 const publishResultsOptions = {
   headers: {
     "Content-Type": "application/json",
-    authorization: config.ams_auth_key,
+    authorization: config.deployment_result_endpoint_key,
   },
 };
 
@@ -54,7 +54,7 @@ async function createConnection() {
   });
   connection.on("close", () => {
     console.error("[AMQP] Connection closed.");
-    if(!isShuttingDown){
+    if (!isShuttingDown) {
       scheduleRestart();
     }
   });
@@ -154,7 +154,9 @@ function scheduleRestart() {
   }
 
   if (connection) {
-    try { connection.close(); } catch (e) {}
+    try {
+      connection.close();
+    } catch (e) {}
   }
 
   console.log("[AMQP] Retrying in 5 seconds...");
@@ -188,10 +190,10 @@ async function gracefulShutdown(signal) {
   process.exit(0);
 }
 
-process.on('SIGINT', () => gracefulShutdown('SIGINT'));
-process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
 
-async function startApp(){
+async function startApp() {
   if (isReconnecting) return;
   isReconnecting = true;
 
@@ -209,7 +211,6 @@ async function startApp(){
     console.error("[AMQP] Startup failed:", err.message);
     scheduleRestart();
   }
-
 }
 
 startApp();
@@ -311,7 +312,8 @@ async function handleSuccess(response) {
     let propagation_integration_environment =
       service.json.integration_environment;
     if (service.merge_environments_on_deploy) {
-      propagation_integration_environment = service.merged_integration_environment_name;
+      propagation_integration_environment =
+        service.merged_integration_environment_name;
     }
 
     setStateArray.push({

--- a/federation-registry-backend-rabbitmq-agent/config.json
+++ b/federation-registry-backend-rabbitmq-agent/config.json
@@ -4,7 +4,7 @@
   "rabbitmq_host": "localhost",
   "rabbitmq_vhost": "/",
   "rabbitmq_update_status_q": "federation-registry-update-status",
-  "ams_auth_key": "banini",
+  "deployment_result_endpoint_key": "banini",
   "express_url": "http://localhost:5000",
   "express_key": "banana",
   "env": "dev"


### PR DESCRIPTION
`ams_auth_key` is only used for `ams/ingest` endpoint, making the name too vague—especially if messaging software other than AMS is used.