### PR TITLE
Rabbitmq related small fixes

### DIFF
--- a/federation-registry-backend-rabbitmq-agent/ResultMessageBatch.js
+++ b/federation-registry-backend-rabbitmq-agent/ResultMessageBatch.js
@@ -1,31 +1,40 @@
 class ResultMessageBatch {
   constructor() {
-    this.messages = [];
+    this.entries = []; // Stores both the fedreg payload and the AMQP message
   }
 
-  addMessage(data) {
+  addMessage(data, amqpMsg) {
     const json = typeof data === 'string' ? data : JSON.stringify(data);
     const base64Data = Buffer.from(json).toString('base64');
 
-    this.messages.push({
-      message: {
-        data: base64Data
-      }
+    this.entries.push({
+      apiPayload: {
+        message: {
+          data: base64Data
+        }
+      },
+      amqpMsg: amqpMsg
     });
   }
 
   isEmpty() {
-    return this.messages.length === 0;
+    return this.entries.length === 0;
   }
 
   clear() {
-    this.messages = [];
+    this.entries = [];
   }
 
+  // Returns ONLY the structure fedreg expects
   toJSON() {
     return {
-      messages: this.messages
+      messages: this.entries.map(entry => entry.apiPayload)
     };
+  }
+
+  // Expose the original messages so they can be ACKed
+  getAmqpMessages() {
+    return this.entries.map(entry => entry.amqpMsg);
   }
 }
 

--- a/federation-registry-backend-rabbitmq-agent/app.js
+++ b/federation-registry-backend-rabbitmq-agent/app.js
@@ -24,6 +24,7 @@ let sendResultTask;
 let sendResultTaskRunning = false;
 let isReconnecting = false;
 let isShuttingDown = false;
+let restartTimeout = null;
 let runIntervalTask = null;
 
 const options = {
@@ -147,18 +148,22 @@ async function setupQueues() {
 }
 
 function scheduleRestart() {
+  if (restartTimeout) return;
+
   if (runIntervalTask) {
     clearInterval(runIntervalTask);
     runIntervalTask = null;
   }
 
   if (connection) {
-    try { connection.close(); } catch (e) {}
+    connection.close().catch(() => {});
+    connection = null;
   }
 
   console.log("[AMQP] Retrying in 5 seconds...");
-  setTimeout(() => {
+  restartTimeout = setTimeout(() => {
     isReconnecting = false;
+    restartTimeout = null;
     startApp();
   }, 5000);
 }

--- a/federation-registry-backend-rabbitmq-agent/app.js
+++ b/federation-registry-backend-rabbitmq-agent/app.js
@@ -155,6 +155,12 @@ function scheduleRestart() {
     runIntervalTask = null;
   }
 
+  if (sendResultTask) {
+    clearInterval(sendResultTask);
+    sendResultTaskRunning = false;
+  }
+  ResultMessageBatch.clear();
+
   if (connection) {
     connection.close().catch(() => {});
     connection = null;

--- a/federation-registry-backend-rabbitmq-agent/app.js
+++ b/federation-registry-backend-rabbitmq-agent/app.js
@@ -215,9 +215,10 @@ async function startApp(){
 startApp();
 
 async function sendResult() {
+  var ingest_url = config.express_url + "/ams/ingest";
   axios
     .post(
-      config.express_url + "/ams/ingest",
+      ingest_url,
       ResultMessageBatch.toJSON(),
       publishResultsOptions,
     )
@@ -231,15 +232,16 @@ async function sendResult() {
       }
     })
     .catch((err) => {
-      console.log("Could not upload result to fedreg, trying again...");
-      console.error("Error:", err);
+      console.log(`Could not upload result to fedreg via ${ingest_url}, trying again...`);
+      console.error(`[Axios Error] ${err.code}: ${err.message}`);
     });
 }
 
 async function setServiceState() {
+  var update_service_state_url = config.express_url + "/agent/set_services_state";
   axios
     .put(
-      config.express_url + "/agent/set_services_state",
+      update_service_state_url,
       setStateArray,
       options,
     )
@@ -252,8 +254,8 @@ async function setServiceState() {
       }
     })
     .catch((err) => {
-      console.log("Could not set service state trying again...");
-      console.error("Error:", err);
+      console.log(`Could not set service state via ${update_service_state_url} trying again...`);
+      console.error(`[Axios Error] ${err.code}: ${err.message}`);
     });
 }
 
@@ -262,8 +264,9 @@ async function run() {
     return;
   }
   // check if config hasn't changed
+  var new_config_url = config.express_url + "/agent/get_new_configurations";
   axios
-    .get(config.express_url + "/agent/get_new_configurations", options)
+    .get(new_config_url, options)
     .then(async function (response) {
       if (response.data.services && response.data.services.length > 0) {
         handleSuccess(response);
@@ -271,7 +274,8 @@ async function run() {
     })
     .catch(function (error) {
       // handle error
-      console.log(error);
+      console.log(`Coudn't fetch new configurations from fedreg via ${new_config_url}`);
+      console.error(`[Axios Error] ${error.code}: ${error.message}`);
     });
 }
 

--- a/federation-registry-backend-rabbitmq-agent/app.js
+++ b/federation-registry-backend-rabbitmq-agent/app.js
@@ -82,8 +82,7 @@ async function setupRabbitMQChannels() {
   const callback = async function callback(msg) {
     if (msg === null) return;
     try {
-      ResultMessageBatch.addMessage(msg.content.toString());
-      consumeChannel.ack(msg);
+      ResultMessageBatch.addMessage(msg.content.toString(), msg);
       if (!sendResultTaskRunning) {
         sendResultTask = setInterval(() => {
           sendResult();
@@ -226,7 +225,10 @@ async function sendResult() {
       if (res.status != 200) {
         console.log("Could not send result to fedreg, trying again...");
       } else {
+        const messagesToAck = ResultMessageBatch.getAmqpMessages();
+        messagesToAck.forEach((msg) => consumeChannel.ack(msg));
         ResultMessageBatch.clear();
+
         clearInterval(sendResultTask);
         sendResultTaskRunning = false;
       }


### PR DESCRIPTION
## Description

What was done:

1. fix: don't leak password in error logs
       Axios error object includes headers too - including the password. Logging just code and message now.
2. fix: ACK rabbitmq messages only after fedreg BE responds with success.
3. prevent a crash caused by multiple overlapping restart loops
4. When durable messages are used(see https://gitlab.ics.muni.cz/perun/perun-proxyidp/rciam-federation-registry-agent/-/merge_requests/12/diffs?commit_id=15c0101bd271f94f217dfeb0eab910f1da90fb49), old messages need to be sometimes tossed away otherwise rabbitmq throws stale message error.

   
Everything later than 1 was discovered during the testing.


## How to test
1. Stop cas deployer. Do anything that requires a deployment. Stop fedreg backend api. Start deployer again. The error logs that can be seen on fedreg rabbit agent should be safe now.
2. Do the same thing like in 1, then restart the fedreg rabbit agent, the message should get logs without the fix, not lost after it(should be kept safe in rabbit).
3. IIRC happened when rabbitmq crashed/turned off. fedreg agent was trying to reconnect - there is this reconnecting loop mechanism which the agent triggered multiple times which crashed him.
4. This is yet another thing that happened just after 3 - so after script no longer crashed because of crazy restarting efforts, it errored anyway because it's messages were marked as stale by rabbitmq. 
