### PR TITLE
Increase server.keepAliveTimeout to 3700 seconds, do not send X-Powered-By header, enable case sensitive and strict mode for router

### DIFF
--- a/federation-registry-backend-api/JavaScript/index.js
+++ b/federation-registry-backend-api/JavaScript/index.js
@@ -203,6 +203,7 @@ var server = app.listen(port, () => {
   function stop() {
     server.close();
 }
+server.keepAliveTimeout = 3700000;
 
 
 

--- a/federation-registry-backend-api/JavaScript/index.js
+++ b/federation-registry-backend-api/JavaScript/index.js
@@ -46,7 +46,7 @@ var corsOptions = {
 
 const app = express();
 
-
+app.disable('x-powered-by');
 app.set('hash',hash);
 db.tenants.getInit().then(async tenants => {
   

--- a/federation-registry-backend-api/JavaScript/routes/index.js
+++ b/federation-registry-backend-api/JavaScript/routes/index.js
@@ -28,7 +28,7 @@ const {
 } = require("../functions/helpers.js");
 const { getUserFromClaims } = require("../functions/util_functions.js");
 const { db } = require("../db");
-var router = require("express").Router();
+var router = require("express").Router({ caseSensitive: true, strict: true });
 var config = require("../config");
 var requested_attributes = require("../tenant_config/requested_attributes.json");
 const customLogger = require("../loggers.js");


### PR DESCRIPTION
As the backend-api is deployed behind a reverse proxy, it is sub-optimal to have the default keepAliveTimeout of 5 seconds. By increasing it to 3700 seconds, we let NGINX to control connection keep-alive, resulting in better connection reuse.

By avoiding sending the X-Powered-By, information disclosure about the software is avoided.

Enabling the case sensitive and strict mode for Express.js router results in unique entry points for the APIs. This improves compatibility with log analytics, and simplifies filtering when web application firewall is used.