### PR TITLE
refactor: service form, allow custom order for form items

### DIFF
--- a/federation-registry-frontend/src/Components/GeneralTab.js
+++ b/federation-registry-frontend/src/Components/GeneralTab.js
@@ -1,0 +1,403 @@
+import React, { useContext, useState, useEffect } from 'react';
+import { useFormikContext } from 'formik';
+import InputRow from './InputRow';
+import {
+  SimpleInput,
+  LogoInput,
+  TextAria,
+  CountrySelect,
+  Contacts,
+  OrganizationField,
+  SimpleCheckbox,
+  SelectEnvironment
+} from './Inputs';
+import { useTranslation } from 'react-i18next';
+import parse from 'html-react-parser';
+import { tenantContext } from '../context';
+import { UrlWarning } from './UrlWarning';
+import { useTabConfig } from './TabConfigProvider';
+
+/**
+ * General tab component - renders all general form fields.
+ * Field order is configurable via form_field_config.json.
+ */
+const GeneralTab = ({ disabled, changes, extraFields = {} }) => {
+  const { t } = useTranslation();
+  const [tenant] = useContext(tenantContext);
+  const { values, errors, touched, handleChange, handleBlur, setFieldValue } = useFormikContext();
+  const { getFieldsForTab, getFieldConfig, isFieldVisible } = useTabConfig();
+  const [logoWarning, setLogoWarning] = useState(false);
+
+  // Get ordered fields for general tab
+  const orderedFieldNames = getFieldsForTab('general');
+
+  /**
+   * Check if logo URL exists
+   */
+  const checkLogoExists = (url) => {
+    if (url) {
+      const img = new Image();
+      img.onload = () => setLogoWarning(false);
+      img.onerror = () => setLogoWarning(true);
+      img.src = url;
+    } else {
+      setLogoWarning(false);
+    }
+  };
+
+  useEffect(() => {
+    checkLogoExists(values.logo_uri);
+  }, [values.logo_uri]);
+
+  /**
+   * Render a standard input field
+   */
+  const renderSimpleInput = (fieldName, placeholder, required = false) => {
+    const config = getFieldConfig('general', fieldName);
+    if (!isFieldVisible(config?.condition, values)) return null;
+
+    return (
+      <InputRow
+        key={fieldName}
+        title={t(`form_${fieldName}`) || fieldName}
+        moreInfo={tenant.form_config.more_info?.[fieldName] || {}}
+        required={required || config?.required}
+        error={errors[fieldName]}
+        touched={touched[fieldName]}
+      >
+        <SimpleInput
+          name={fieldName}
+          placeholder={placeholder}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          value={values[fieldName] || ''}
+          isInvalid={!!errors[fieldName]}
+          disabled={disabled}
+          changed={changes?.[fieldName] ? true : null}
+        />
+        {fieldName === 'website_url' && <UrlWarning url={values.website_url} touched={touched.website_url} />}
+        {fieldName === 'policy_uri' && <UrlWarning url={values.policy_uri} touched={touched.policy_uri} />}
+      </InputRow>
+    );
+  };
+
+  /**
+   * Render extra field based on its type
+   */
+  const renderExtraField = (name, fieldData) => {
+    const config = getFieldConfig('general', name);
+    const required = fieldData.required?.includes(values.integration_environment);
+
+    if (!isFieldVisible(config?.condition, values)) return null;
+
+    if (fieldData.type === 'boolean') {
+      return (
+        <InputRow
+          key={name}
+          title={fieldData.title}
+          moreInfo={tenant.form_config.more_info?.[name] || {}}
+          required={required}
+          error={errors[name]}
+          touched={touched[name]}
+        >
+          <SimpleCheckbox
+            name={name}
+            label={parse(fieldData.desc)}
+            moreinfo={tenant.form_config.more_info?.[name]}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            disabled={disabled || (fieldData.tag === 'once' && values[name])}
+            value={values[name]}
+            changed={changes?.[name] ? true : null}
+          />
+        </InputRow>
+      );
+    }
+
+    if (fieldData.type === 'string') {
+      return (
+        <InputRow
+          key={name}
+          title={fieldData.title}
+          description={fieldData.desc}
+          moreInfo={tenant.form_config.more_info?.[name] || {}}
+          required={required}
+          error={errors[name]}
+          touched={touched[name]}
+        >
+          <SimpleInput
+            name={name}
+            placeholder={fieldData.placeholder}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values[name]}
+            isInvalid={!!errors[name]}
+            disabled={disabled}
+            changed={changes?.[name] ? true : null}
+          />
+          {fieldData.tag === 'url' && <UrlWarning url={values[name]} touched={touched[name]} />}
+        </InputRow>
+      );
+    }
+
+    return null;
+  };
+
+  /**
+   * Get organization visibility based on config
+   */
+  const showOrganization = () => {
+    const orgConfig = tenant.form_config.extra_fields?.organization;
+    return orgConfig && !orgConfig.hide?.includes(values.integration_environment);
+  };
+
+  /**
+   * Get organization required status
+   */
+  const isOrgRequired = () => {
+    return tenant.form_config.extra_fields?.organization?.required?.includes(values.integration_environment);
+  };
+
+  // Split extra fields by tag
+  const regularExtraFields = Object.entries(extraFields)
+    .filter(([_, data]) => data.tab === 'general' && data.tag !== 'once');
+
+  const onceExtraFields = Object.entries(extraFields)
+    .filter(([_, data]) => data.tab === 'general' && data.tag === 'once');
+
+  return (
+    <div className="general-tab-content">
+      {/* Render fields in configured order */}
+      {orderedFieldNames.map((fieldName) => {
+        const config = getFieldConfig('general', fieldName);
+        if (!isFieldVisible(config?.condition, values)) return null;
+
+        switch (fieldName) {
+          case 'service_name':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_service_name')}
+                moreInfo={tenant.form_config.more_info?.service_name || {}}
+                required={true}
+                description={t('form_service_name_desc')}
+                error={errors.service_name}
+                touched={touched.service_name}
+              >
+                <SimpleInput
+                  name="service_name"
+                  placeholder={t('form_type_prompt')}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  value={values.service_name || ''}
+                  isInvalid={!!errors.service_name}
+                  disabled={disabled}
+                  changed={changes?.service_name ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'integration_environment':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_integration_environment')}
+                moreInfo={tenant.form_config.more_info?.integration_environment || {}}
+                required={true}
+                extraClass="select-col"
+                error={errors.integration_environment}
+                touched={touched.integration_environment}
+              >
+                <SelectEnvironment
+                  onBlur={handleBlur}
+                  optionsTitle={tenant.form_config.integration_environment.map(capitalWords)}
+                  options={tenant.form_config.integration_environment}
+                  name="integration_environment"
+                  values={values}
+                  isInvalid={!!errors.integration_environment}
+                  onChange={handleChange}
+                  disabled={disabled || tenant.form_config.integration_environment.length === 1}
+                  changed={changes?.integration_environment ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'logo_uri':
+            return (
+              <InputRow key={fieldName} title={t('form_logo')} moreInfo={{}}>
+                <LogoInput
+                  value={values.logo_uri || ''}
+                  name="logo_uri"
+                  description={t('form_logo_desc')}
+                  moreInfo={tenant.form_config.more_info?.logo_uri || {}}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  error={errors.logo_uri}
+                  touched={touched.logo_uri}
+                  isInvalid={!!errors.logo_uri}
+                  disabled={disabled}
+                  warning={logoWarning}
+                  changed={changes?.logo_uri ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'website_url':
+            return renderSimpleInput('website_url', t('form_url_placeholder'), false);
+
+          case 'service_description':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_description')}
+                moreInfo={tenant.form_config.more_info?.service_description || {}}
+                required={true}
+                description={t('form_description_desc')}
+                error={errors.service_description}
+                touched={touched.service_description}
+              >
+                <TextAria
+                  name="service_description"
+                  placeholder={t('form_type_prompt')}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  value={values.service_description || ''}
+                  isInvalid={!!errors.service_description}
+                  disabled={disabled}
+                  changed={changes?.service_description ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'country':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_country') || 'Select country'}
+                moreInfo={tenant.form_config.more_info?.country || {}}
+                required={tenant.form_config.more_info?.country?.required?.includes(values.integration_environment)}
+                extraClass="select-col"
+                error={errors.country}
+                touched={touched.country}
+              >
+                <CountrySelect
+                  onBlur={handleBlur}
+                  placeholder="Select country"
+                  name="country"
+                  values={values}
+                  isInvalid={!!errors.country}
+                  onChange={handleChange}
+                  disabled={disabled}
+                  changed={changes?.country ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'organization_name':
+            if (!showOrganization()) return null;
+            return (
+              <InputRow
+                key={fieldName}
+                title="Organisation"
+                moreInfo={tenant.form_config.more_info?.organization_name || {}}
+                required={isOrgRequired()}
+                description="Search for your organisation"
+                error={errors.organization_name}
+                touched={touched.organization_name}
+              >
+                <OrganizationField
+                  name="organization_name"
+                  placeholder="Type the name of your organization"
+                  onChange={handleChange}
+                  values={values}
+                  isInvalid={!!errors.organization_name}
+                  setFieldTouched={(field, val) => setFieldValue(field, val)}
+                  disabled={disabled}
+                  setFieldValue={setFieldValue}
+                  changed={changes?.organization_name ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'organization_url':
+            if (!showOrganization()) return null;
+            return (
+              <InputRow
+                key={fieldName}
+                title="Organisation Website URL"
+                moreInfo={tenant.form_config.more_info?.organization_url || {}}
+                required={isOrgRequired()}
+                description="Link to the organization's website"
+                error={errors.organization_url}
+                touched={touched.organization_url}
+              >
+                <SimpleInput
+                  name="organization_url"
+                  placeholder={t('form_type_prompt')}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  value={values.organization_url || ''}
+                  isInvalid={!!errors.organization_url}
+                  disabled={disabled}
+                  changed={changes?.organization_url ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'policy_uri':
+            return renderSimpleInput('policy_uri', t('form_url_placeholder'), false);
+
+          case 'contacts':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_contacts')}
+                moreInfo={tenant.form_config.more_info?.contacts || {}}
+                required={true}
+                description={t('form_contacts_desc')}
+                error={typeof errors.contacts === 'string' ? errors.contacts : null}
+                touched={touched.contacts}
+              >
+                <Contacts
+                  name="contacts"
+                  values={values.contacts}
+                  placeholder={t('form_type_prompt')}
+                  empty={typeof errors.contacts === 'string'}
+                  error={errors.contacts}
+                  touched={touched.contacts}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  setFieldTouched={(field, val) => setFieldValue(field, val)}
+                  disabled={disabled}
+                  changed={changes?.contacts ? true : null}
+                />
+              </InputRow>
+            );
+
+          default:
+            return null;
+        }
+      })}
+
+      {/* Render extra fields */}
+      {regularExtraFields.map(([name, fieldData]) => renderExtraField(name, fieldData))}
+      {onceExtraFields.map(([name, fieldData]) => renderExtraField(name, fieldData))}
+    </div>
+  );
+};
+
+/**
+ * Capitalize words in a string or array
+ */
+const capitalWords = (item) => {
+  if (typeof item === 'string') {
+    return item
+      .toLowerCase()
+      .split(' ')
+      .map((word) => word.charAt(0).toUpperCase() + word.substring(1))
+      .join(' ');
+  }
+  return item;
+};
+
+export default GeneralTab;

--- a/federation-registry-frontend/src/Components/Inputs.js
+++ b/federation-registry-frontend/src/Components/Inputs.js
@@ -603,8 +603,6 @@ export function AccessTokenValidationModel(props) {
 
 export function AuthMethRadioList(props) {
   const [show, setShow] = useState(false);
-  // const authMethod = props.values.token_endpoint_auth_method;
-  // const signingAlg = props.values.token_endpoint_auth_signing_alg;
   const setFieldValue = props.setFieldValue;
   const target = useRef(null);
   const [tenant] = useContext(tenantContext);
@@ -615,14 +613,14 @@ export function AuthMethRadioList(props) {
         props.values.token_endpoint_auth_method === "private_key_jwt") &&
       !props.values.token_endpoint_auth_signing_alg
     ) {
-      setFieldValue("token_endpoint_auth_signing_alg", "RS256");
+      setFieldValue?.("token_endpoint_auth_signing_alg", "RS256");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.values.token_endpoint_auth_method]);
 
   useEffect(() => {
-    if (tenant.form_config.dynamic_fields.includes("allow_introspection")) {
-      setFieldValue(
+    if (tenant.form_config.dynamic_fields?.includes("allow_introspection")) {
+      setFieldValue?.(
         "allow_introspection",
         props.values.token_endpoint_auth_method !== "none"
       );
@@ -1492,7 +1490,7 @@ export function ListInputArray(props) {
         ) : null}
       </thead>
       <tbody>
-        {[...props.defaultValues].map((item, index) => (
+        {[...(props.defaultValues || [])].map((item, index) => (
           <ListInputArrayInput1
             key={index}
             index={index}
@@ -1510,7 +1508,7 @@ export function ListInputArray(props) {
               ...(props.values || []),
               ...(props?.changed?.D ? props?.changed?.D : []),
             ].map((item, index) => {
-              if (!props.defaultValues.includes(item)) {
+              if (!(props.defaultValues || []).includes(item)) {
                 return (
                   <React.Fragment key={index}>
                     <ListInputArrayInput2

--- a/federation-registry-frontend/src/Components/OidcFields.js
+++ b/federation-registry-frontend/src/Components/OidcFields.js
@@ -1,0 +1,487 @@
+import React, { useContext } from 'react';
+import { useFormikContext } from 'formik';
+import InputRow from './InputRow';
+import {
+  SimpleRadio,
+  AuthMethRadioList,
+  ClientSecret,
+  Select,
+  PublicKey,
+  ListInputArray,
+  ListInput,
+  TimeInput,
+  RefreshToken,
+  DeviceCode,
+  AccessTokenValidationModel,
+  SimpleCheckbox
+} from './Inputs';
+import { useTranslation } from 'react-i18next';
+import { tenantContext } from '../context';
+import { formatDuration } from '../helpers';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+/**
+ * OIDC-specific form fields component.
+ * Field order is configurable via form_field_config.json.
+ */
+const OidcFields = ({ disabled, changes }) => {
+  const { t } = useTranslation();
+  const [tenant] = useContext(tenantContext);
+  const { values, errors, touched, handleChange, handleBlur, setFieldValue } = useFormikContext();
+
+  // Define OIDC-specific fields with their display order
+  const oidcFieldOrder = [
+    { name: 'application_type', order: 1 },
+    { name: 'grant_types', order: 2 },
+    { name: 'token_endpoint_auth_method', order: 3 },
+    { name: 'client_secret', order: 4 },
+    { name: 'token_endpoint_auth_signing_alg', order: 5 },
+    { name: 'jwks', order: 6 },
+    { name: 'jwks_uri', order: 7 },
+    { name: 'allow_introspection', order: 8 },
+    { name: 'scope', order: 9 },
+    { name: 'redirect_uris', order: 10 },
+    { name: 'post_logout_redirect_uris', order: 11 },
+    { name: 'code_challenge_method', order: 12 },
+    { name: 'refresh_token_validity_seconds', order: 13 },
+    { name: 'device_code_validity_seconds', order: 14 },
+    { name: 'access_token_validation_model', order: 15 },
+    { name: 'access_token_validity_seconds', order: 16 },
+    { name: 'id_token_timeout_seconds', order: 17 }
+  ];
+
+  return (
+    <div className="oidc-fields-content">
+      {oidcFieldOrder.map(({ name: fieldName }) => {
+        // Conditional rendering based on field-specific logic
+        switch (fieldName) {
+
+          case 'application_type':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_application_type') || 'Application Type'}
+                moreInfo={tenant.form_config.more_info?.application_type || {}}
+                required={true}
+                error={errors.application_type}
+                touched={touched.application_type}
+              >
+                <SimpleRadio
+                  name="application_type"
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  values={values}
+                  radio_items={['WEB', 'NATIVE']}
+                  radio_items_titles={['Web', 'Native']}
+                  value={values.application_type}
+                  isInvalid={!!errors.application_type}
+                  disabled={disabled}
+                  changed={changes?.application_type ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'grant_types':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_grant_types')}
+                moreInfo={tenant.form_config.more_info?.grant_types || {}}
+                error={errors.grant_types}
+                touched={touched.grant_types}
+              >
+                <ListInputArray
+                  name="grant_types"
+                  values={values.grant_types}
+                  listItems={tenant.form_config.grant_types}
+                  disabled={disabled}
+                  deprecated_options={tenant.form_config.grant_types_deprecated}
+                  changed={changes?.grant_types ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'token_endpoint_auth_method':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_token_endpoint_auth_method') || 'Token Endpoint Authorization Method'}
+                moreInfo={tenant.form_config.more_info?.token_endpoint_auth_method || {}}
+                required={true}
+                error={errors.token_endpoint_auth_method || errors.code_challenge_method}
+                touched={touched.token_endpoint_auth_method}
+              >
+                <AuthMethRadioList
+                  name="token_endpoint_auth_method"
+                  values={values}
+                  onChange={handleChange}
+                  radio_items={tenant.form_config.token_endpoint_auth_method}
+                  radio_items_titles={tenant.form_config.token_endpoint_auth_method_title}
+                  disabled={disabled}
+                  changed={changes?.token_endpoint_auth_method ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'client_secret':
+            if (!['private_key_jwt', 'none'].includes(values.token_endpoint_auth_method)) {
+              return (
+                <InputRow
+                  key={fieldName}
+                  title={t('form_client_secret')}
+                  moreInfo={tenant.form_config.more_info?.client_secret || {}}
+                  required={true}
+                  error={errors.client_secret}
+                  touched={touched.client_secret}
+                >
+                  <ClientSecret
+                    name="client_secret"
+                    client_secret={values.client_secret}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    generate_client_secret={values.generate_client_secret}
+                    isInvalid={!!errors.client_secret}
+                    disabled={disabled}
+                    changed={changes?.client_secret ? true : null}
+                  />
+                </InputRow>
+              );
+            }
+            return null;
+
+          case 'token_endpoint_auth_signing_alg':
+            if (['private_key_jwt', 'client_secret_jwt'].includes(values.token_endpoint_auth_method)) {
+              return (
+                <InputRow
+                  key={fieldName}
+                  title={t('form_token_endpoint_auth_signing_alg') || 'Token Endpoint Signing Algorithm'}
+                  moreInfo={tenant.form_config.more_info?.token_endpoint_auth_signing_alg || {}}
+                  required={true}
+                  extraClass="select-col"
+                  error={errors.token_endpoint_auth_signing_alg}
+                  touched={touched.token_endpoint_auth_signing_alg}
+                >
+                  <Select
+                    onBlur={handleBlur}
+                    optionsTitle={tenant.form_config.token_endpoint_auth_signing_alg_title}
+                    options={tenant.form_config.token_endpoint_auth_signing_alg}
+                    default="RS256"
+                    name="token_endpoint_auth_signing_alg"
+                    values={values}
+                    isInvalid={!!errors.token_endpoint_auth_signing_alg}
+                    onChange={handleChange}
+                    disabled={disabled}
+                    changed={changes?.token_endpoint_auth_signing_alg ? true : null}
+                  />
+                </InputRow>
+              );
+            }
+            return null;
+
+          case 'jwks':
+            if (values.token_endpoint_auth_method === 'private_key_jwt') {
+              return (
+                <InputRow
+                  key={fieldName}
+                  title={t('form_jwks') || 'Public Key Set'}
+                  moreInfo={tenant.form_config.more_info?.jwks || {}}
+                  required={true}
+                  description="URL for the client's JSON Web Key set (must be reachable by the server)"
+                  extraClass="select-col"
+                  error={errors.jwks || errors.jwks_uri}
+                  touched={touched.jwks || touched.jwks_uri}
+                >
+                  <PublicKey
+                    onBlur={handleBlur}
+                    values={values}
+                    setvalue={(field, value, validate) => setFieldValue(field, value, validate)}
+                    isInvalid={!!(errors.jwks_uri || errors.jwks)}
+                    datatype="json"
+                    onChange={handleChange}
+                    disabled={disabled}
+                    changed={changes?.jwks || changes?.jwks_uri ? true : false}
+                  />
+                </InputRow>
+              );
+            }
+            return null;
+
+          case 'allow_introspection':
+            return (
+              <InputRow key={fieldName} title={t('form_allow_introspection')} moreInfo={tenant.form_config.more_info?.allow_introspection || {}}>
+                <div className="simple_checkbox_container">
+                  <SimpleCheckbox
+                    name="allow_introspection"
+                    label={t('form_allow_introspection_desc')}
+                    onChange={handleChange}
+                    moreinfo={tenant.form_config.more_info?.allow_introspection}
+                    disabled={disabled || tenant.form_config.dynamic_fields?.includes('allow_introspection')}
+                    value={values.allow_introspection}
+                    changed={changes?.allow_introspection ? true : null}
+                  />
+                </div>
+              </InputRow>
+            );
+
+          case 'scope':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_scope')}
+                moreInfo={tenant.form_config.more_info?.scope || {}}
+                required={values?.grant_types?.length > 0}
+                description={t('form_scope_desc')}
+                error={typeof errors.scope === 'string' ? errors.scope : null}
+                touched={touched.scope}
+              >
+                <ListInputArray
+                  name="scope"
+                  values={values.scope}
+                  placeholder={t('form_type_prompt')}
+                  defaultValues={tenant.form_config.scope}
+                  error={errors.scope}
+                  touched={touched.scope}
+                  disabled={disabled}
+                  onBlur={handleBlur}
+                  changed={changes?.scope ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'redirect_uris':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_redirect_uris')}
+                moreInfo={tenant.form_config.more_info?.redirect_uris || {}}
+                required={values?.grant_types?.includes('implicit') || values?.grant_types?.includes('authorization_code')}
+                description={t('form_redirect_uris_desc')}
+                error={typeof errors.redirect_uris === 'string' ? errors.redirect_uris : null}
+                touched={touched.redirect_uris}
+              >
+                <ListInput
+                  name="redirect_uris"
+                  values={values.redirect_uris}
+                  placeholder={t('form_type_prompt')}
+                  empty={typeof errors.redirect_uris === 'string'}
+                  error={errors.redirect_uris}
+                  touched={touched.redirect_uris}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  integrationEnvironment={values.integration_environment}
+                  setFieldTouched={(field, val) => setFieldValue(field, val)}
+                  disabled={disabled}
+                  changed={changes?.redirect_uris ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'post_logout_redirect_uris':
+            if (!tenant.form_config.disabled_fields?.includes('post_logout_redirect_uris')) {
+              return (
+                <InputRow
+                  key={fieldName}
+                  title={t('form_post_logout_redirect_uris')}
+                  moreInfo={tenant.form_config.more_info?.post_logout_redirect_uris || {}}
+                  description={t('form_redirect_uris_desc')}
+                  error={typeof errors.post_logout_redirect_uris === 'string' ? errors.post_logout_redirect_uris : null}
+                  touched={touched.post_logout_redirect_uris}
+                >
+                  <ListInput
+                    name="post_logout_redirect_uris"
+                    values={values.post_logout_redirect_uris}
+                    placeholder={t('form_type_prompt')}
+                    empty={typeof errors.post_logout_redirect_uris === 'string'}
+                    error={errors.post_logout_redirect_uris}
+                    touched={touched.post_logout_redirect_uris}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    integrationEnvironment={values.integration_environment}
+                    setFieldTouched={(field, val) => setFieldValue(field, val)}
+                    disabled={disabled}
+                    changed={changes?.post_logout_redirect_uris ? true : null}
+                  />
+                </InputRow>
+              );
+            }
+            return null;
+
+          case 'code_challenge_method':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_code_challenge_method')}
+                moreInfo={tenant.form_config.more_info?.code_challenge_method || {}}
+                required={true}
+                extraClass="select-col"
+                error={errors.code_challenge_method}
+                touched={touched.code_challenge_method}
+              >
+                <Select
+                  onBlur={handleBlur}
+                  optionsTitle={[
+                    `PKCE will not be used for this service ${values.grant_types?.includes('authorization_code') ? '(disabled)' : ''}`,
+                    'Plain code challenge (deprecated)',
+                    'SHA-256 hash algorithm (recommended)'
+                  ]}
+                  options={['', 'plain', 'S256']}
+                  name="code_challenge_method"
+                  values={values}
+                  isInvalid={!!errors.code_challenge_method}
+                  onChange={handleChange}
+                  setFieldValue={(val) => setFieldValue('code_challenge_method', val)}
+                  recommended="S256"
+                  default={values.code_challenge_method || ''}
+                  disabled={disabled}
+                  changed={changes?.code_challenge_method ? true : null}
+                />
+                <div className="pkce-tooltip">
+                  <FontAwesomeIcon icon={faExclamationTriangle} />
+                  Enabling PKCE is highly recommended to avoid code injection and code replay attacks.
+                </div>
+              </InputRow>
+            );
+
+          case 'refresh_token_validity_seconds':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_refresh_token_validity_seconds')}
+                moreInfo={tenant.form_config.more_info?.refresh_token_validity_seconds || {}}
+                required={values.scope?.includes('offline_access')}
+                extraClass="time-input"
+                error={errors.refresh_token_validity_seconds}
+                touched={touched.refresh_token_validity_seconds}
+                description={`${t('form_refresh_token_validity_seconds_desc')} ${t('min_value_is')} ${formatDuration(
+                  tenant.form_config.more_info?.refresh_token_validity_seconds?.min ?? 1
+                )}. ${t('max_value_is')} ${formatDuration(
+                  tenant.form_config.more_info?.refresh_token_validity_seconds?.max ??
+                  tenant.form_config.refresh_token_validity_seconds ??
+                  34560000
+                )}.`}
+              >
+                <RefreshToken
+                  values={values}
+                  onBlur={handleBlur}
+                  isInvalid={!!errors.refresh_token_validity_seconds}
+                  onChange={handleChange}
+                  disabled={disabled}
+                  errors={errors}
+                  setFieldValue={setFieldValue}
+                  changed={changes}
+                />
+              </InputRow>
+            );
+
+          case 'device_code_validity_seconds':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_device_code_validity_seconds')}
+                moreInfo={tenant.form_config.more_info?.device_code_validity_seconds || {}}
+                required={values?.grant_types?.includes('urn:ietf:params:oauth:grant-type:device_code')}
+                extraClass="time-input"
+                error={errors.device_code_validity_seconds}
+                touched={touched.device_code_validity_seconds}
+              >
+                <DeviceCode
+                  onBlur={handleBlur}
+                  values={values}
+                  setFieldValue={setFieldValue}
+                  errors={errors}
+                  isInvalid={!!errors.device_code_validity_seconds}
+                  onChange={handleChange}
+                  disabled={disabled}
+                  changed={changes}
+                />
+              </InputRow>
+            );
+
+          case 'access_token_validation_model':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_access_token_validation_model')}
+                moreInfo={tenant.form_config.more_info?.access_token_validation_model || {}}
+                required={true}
+                error={errors.access_token_validation_model}
+                touched={touched.access_token_validation_model}
+              >
+                <AccessTokenValidationModel
+                  name="access_token_validation_model"
+                  values={values}
+                  setFieldValue={setFieldValue}
+                  disabled={disabled}
+                  changed={changes?.access_token_validation_model ? true : null}
+                  limits={tenant.form_config.more_info.access_token_validity_seconds.max}
+                />
+              </InputRow>
+            );
+
+          case 'access_token_validity_seconds':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_access_token_validity_seconds')}
+                moreInfo={tenant.form_config.more_info?.access_token_validity_seconds || {}}
+                required={true}
+                extraClass="time-input"
+                error={errors.access_token_validity_seconds}
+                touched={touched.access_token_validity_seconds}
+                description={`${t('form_access_token_validity_seconds_desc')} ${t('min_value_is')} ${formatDuration(
+                  tenant.form_config.more_info?.access_token_validity_seconds?.min ?? 1
+                )}. ${t('max_value_is')} ${formatDuration(
+                  tenant.form_config.more_info?.access_token_validity_seconds?.max?.[
+                    values.access_token_validation_model || 'OFFLINE_VERIFIABLE'
+                  ] ??
+                  tenant.form_config.more_info?.access_token_validity_seconds?.max?.OFFLINE_VERIFIABLE ??
+                  tenant.form_config.access_token_validity_seconds ??
+                  21600
+                )}.`}
+              >
+                <TimeInput
+                  name="access_token_validity_seconds"
+                  value={values.access_token_validity_seconds}
+                  isInvalid={!!errors.access_token_validity_seconds}
+                  onBlur={handleBlur}
+                  onChange={handleChange}
+                  disabled={disabled}
+                  changed={changes?.access_token_validity_seconds ? true : null}
+                />
+              </InputRow>
+            );
+
+          case 'id_token_timeout_seconds':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_id_token_timeout_seconds')}
+                moreInfo={tenant.form_config.more_info?.id_token_timeout_seconds || {}}
+                required={true}
+                extraClass="time-input"
+                error={errors.id_token_timeout_seconds}
+                touched={touched.id_token_timeout_seconds}
+                description={t('form_id_token_timeout_seconds_desc')}
+              >
+                <TimeInput
+                  name="id_token_timeout_seconds"
+                  value={values.id_token_timeout_seconds}
+                  isInvalid={!!errors.id_token_timeout_seconds}
+                  onBlur={handleBlur}
+                  onChange={handleChange}
+                  disabled={disabled}
+                  changed={changes?.id_token_timeout_seconds ? true : null}
+                />
+              </InputRow>
+            );
+
+          default:
+            return null;
+        }
+      })}
+    </div>
+  );
+};
+
+export default OidcFields;

--- a/federation-registry-frontend/src/Components/ProtocolTab.js
+++ b/federation-registry-frontend/src/Components/ProtocolTab.js
@@ -1,0 +1,78 @@
+import React, { useContext, useState } from 'react';
+import { useFormikContext } from 'formik';
+import InputRow from './InputRow';
+import { Select } from './Inputs';
+import { useTranslation } from 'react-i18next';
+import { tenantContext } from '../context';
+import OidcFields from './OidcFields';
+import SamlFields from './SamlFields';
+
+/**
+ * Protocol tab component - wrapper for protocol-specific fields.
+ * Renders OIDC or SAML fields based on selected protocol.
+ * Field order is configurable via form_field_config.json.
+ */
+const ProtocolTab = ({ disabled, changes }) => {
+  const { t } = useTranslation();
+  const [tenant] = useContext(tenantContext);
+  const { values, errors, touched, handleChange, handleBlur } = useFormikContext();
+
+  // Metadata state lifted up for sharing between components
+  const [metadataLoaded, setMetadataLoaded] = useState({
+    supported_attributes: [],
+    unsupported_attributes: [],
+    entity_id: null,
+    metadata_url: null
+  });
+  const [metadataAsyncError, setMetadataAyncError] = useState('');
+  const [metadataWarning, setMetadataWarning] = useState();
+
+  const metadataState = {
+    metadataLoaded,
+    setMetadataLoaded,
+    metadataAsyncError,
+    setMetadataAyncError,
+    metadataWarning,
+    setMetadataWarning
+  };
+
+  /**
+   * Get protocol options with capitalized titles
+   */
+  const getProtocolOptions = (protocols) => {
+    return protocols.map((p) => p.toUpperCase() + ' Service');
+  };
+
+  return (
+    <div className="protocol-tab-content">
+      {/* Protocol Selection */}
+      <InputRow
+        title={t('form_protocol')}
+        required={true}
+        extraClass="select-col"
+        error={errors.protocol}
+        touched={touched.protocol}
+      >
+        <Select
+          onBlur={handleBlur}
+          optionsTitle={['Select one option', ...getProtocolOptions(tenant.form_config.protocol)]}
+          options={['', ...tenant.form_config.protocol]}
+          name="protocol"
+          values={values}
+          isInvalid={!!errors.protocol}
+          onChange={handleChange}
+          disabled={disabled}
+          changed={changes?.protocol ? true : null}
+        />
+      </InputRow>
+
+      {/* OIDC Fields */}
+      {values.protocol === 'oidc' && <OidcFields disabled={disabled} changes={changes} />}
+
+      {/* SAML Fields */}
+      {values.protocol === 'saml' && <SamlFields disabled={disabled} changes={changes} metadataState={metadataState} />}
+    </div>
+  );
+};
+
+export default ProtocolTab;

--- a/federation-registry-frontend/src/Components/SamlFields.js
+++ b/federation-registry-frontend/src/Components/SamlFields.js
@@ -1,0 +1,281 @@
+import React, { useContext, useState, useEffect } from 'react';
+import { useFormikContext } from 'formik';
+import InputRow from './InputRow';
+import { SimpleInput, MetadataInput } from './Inputs';
+import { SamlAttributesInput } from './SamlAttributes';
+import { useTranslation } from 'react-i18next';
+import { tenantContext } from '../context';
+import { reg } from '../regex';
+import { ConfirmationModal } from './Modals';
+import { UrlWarning } from './UrlWarning';
+
+var metadataCheckTimeout;
+
+/**
+ * SAML-specific form fields component.
+ * Field order is configurable via form_field_config.json.
+ */
+const SamlFields = ({ disabled, changes, metadataState }) => {
+  const { t } = useTranslation();
+  const [tenant] = useContext(tenantContext);
+  const { values, errors, touched, handleChange, setFieldValue } = useFormikContext();
+
+  const [checkingAvailability, setCheckingAvailability] = useState(false);
+  const [checkedId, setCheckedId] = useState();
+  const [checkedEnvironment, setCheckedEnvironment] = useState();
+
+  const { metadataLoaded, setMetadataLoaded, metadataAsyncError, setMetadataAyncError, metadataWarning, setMetadataWarning } = metadataState;
+
+  // Define SAML-specific fields with their display order
+  const samlFieldOrder = [
+    { name: 'entity_id', order: 1 },
+    { name: 'metadata_url', order: 2 },
+    { name: 'requested_attributes', order: 3 }
+  ];
+
+  /**
+   * Fetch and process metadata from URL
+   */
+  const getMetadata = (url, resolve, setRequestedAttributes) => {
+    fetch(
+      `${process.env.REACT_APP_API_HOST || ''}util/metadata_info?metadata_url=${encodeURIComponent(url)}`,
+      {
+        method: 'GET',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' }
+      }
+    )
+      .then(async (response) => {
+        if (response.status === 200 || response.status === 304) {
+          const metadata = await response.json();
+          const loadMetadata = !metadataLoaded.metadata_url || url !== metadataLoaded.metadata_url;
+
+          if (loadMetadata) {
+            setMetadataLoaded(metadata);
+          }
+
+          if (tenant.form_config.more_info.requested_attributes && !tenant.form_config.more_info.requested_attributes.disabled) {
+            if (metadata.supported_attributes.length === 0 && !metadata.entity_id) {
+              setRequestedAttributes(tenant.form_config.requested_attributes);
+              setMetadataWarning('Could not find an Entity Id or any Requested Attributes from this Metadata Url.');
+            } else if (metadata.supported_attributes.length === 0) {
+              setRequestedAttributes(tenant.form_config.defaultValues.requested_attributes);
+              setMetadataWarning('Could not find any Requested Attributes from this Metadata Url.');
+            } else if (!metadata.entity_id) {
+              setMetadataWarning('Could not find an Entity Id from this Metadata Url.');
+            }
+          } else {
+            setRequestedAttributes(tenant.form_config.defaultValues.requested_attributes);
+            metadata.supported_attributes = [];
+          }
+        } else {
+          setMetadataAyncError(response.statusText);
+          if (resolve) resolve(true);
+        }
+      })
+      .catch(() => {
+        setMetadataAyncError('Could not get response from Metadata url');
+        if (resolve) resolve(true);
+      });
+  };
+
+  /**
+   * Check entity ID availability
+   */
+  const checkEntityAvailability = (value) => {
+    clearTimeout(metadataCheckTimeout);
+
+    if (!value || !reg.regUrl.test(value)) {
+      setCheckingAvailability(false);
+      return;
+    }
+
+    if (value === checkedId && values.integration_environment === checkedEnvironment) {
+      setCheckingAvailability(false);
+      return;
+    }
+
+    setCheckingAvailability(true);
+
+    metadataCheckTimeout = setTimeout(() => {
+      fetch(
+        `${process.env.REACT_APP_API_HOST || ''}tenants/${tenant.tenant_name}/check-availability?value=${encodeURIComponent(value)}&protocol=saml&environment=${values.integration_environment}`,
+        {
+          method: 'GET',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
+        .then((response) => {
+          if (response.status === 200) {
+            return response.json();
+          }
+          return false;
+        })
+        .then((response) => {
+          setCheckedId(value);
+          setCheckedEnvironment(values.integration_environment);
+          setCheckingAvailability(false);
+
+          // Availability check result handled above
+        })
+        .catch(() => {
+          setCheckingAvailability(false);
+        });
+    }, 1000);
+  };
+
+  useEffect(() => {
+    checkEntityAvailability(values.entity_id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values.entity_id, values.integration_environment]);
+
+  return (
+    <div className="saml-fields-content">
+      {/* Confirmation Modal for metadata loading */}
+      {metadataLoaded.supported_attributes.length > 0 ||
+      (metadataLoaded.entity_id && (!values.entity_id || values.entity_id !== metadataLoaded.entity_id)) ? (
+        <ConfirmationModal
+          active={true}
+          close={() => {
+            if (metadataLoaded.supported_attributes.length > 0) {
+              setMetadataLoaded({ ...metadataLoaded, supported_attributes: [] });
+            } else if (metadataLoaded.entity_id) {
+              setMetadataLoaded({ ...metadataLoaded, entity_id: '' });
+            }
+          }}
+          action={() => {
+            if (metadataLoaded.supported_attributes.length > 0) {
+              setFieldValue('requested_attributes', metadataLoaded.supported_attributes);
+              setMetadataLoaded({ ...metadataLoaded, supported_attributes: [] });
+            } else {
+              setFieldValue('entity_id', metadataLoaded.entity_id);
+              setMetadataLoaded({ ...metadataLoaded, entity_id: '' });
+            }
+          }}
+          title={
+            metadataLoaded.supported_attributes.length > 0
+              ? 'Do you wish to load the requested attributes contained in the Metadata Url?'
+              : metadataLoaded.entity_id && !values.entity_id
+              ? 'Do you wish to use the Entity Id contained in the Metadata Url?'
+              : metadataLoaded.entity_id && metadataLoaded.entity_id !== values.entity_id
+              ? 'The Metadata Url contains a different Entity Id from the provided, do you wish to replace it?'
+              : ''
+          }
+          message={
+            metadataLoaded.supported_attributes.length > 0
+              ? `${metadataLoaded.supported_attributes.length}${
+                  metadataLoaded.unsupported_attributes.length > 0
+                    ? ` out of ${metadataLoaded.supported_attributes.length + metadataLoaded.unsupported_attributes.length}`
+                    : ''
+                } attributes found are supported and can be added in the service configuration.`
+              : metadataLoaded.entity_id && (!values.entity_id || metadataLoaded.entity_id !== values.entity_id)
+              ? `Entity Id: ${metadataLoaded.entity_id}`
+              : ''
+          }
+          accept="Yes"
+          decline="No"
+        />
+      ) : null}
+
+      {/* Render fields in configured order */}
+      {samlFieldOrder.map(({ name: fieldName }) => {
+        switch (fieldName) {
+          case 'entity_id':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_entity_id')}
+                moreInfo={tenant.form_config.more_info?.entity_id || {}}
+                required={true}
+                description={t('form_entity_id_desc')}
+                error={checkingAvailability ? null : errors.entity_id}
+                touched={touched.entity_id}
+              >
+                <SimpleInput
+                  name="entity_id"
+                  placeholder={t('form_type_prompt')}
+                  onChange={(e) => {
+                    setFieldValue('entity_id', e.target.value);
+                    handleChange(e);
+                  }}
+                  value={values.entity_id}
+                  isInvalid={!!errors.entity_id && touched.entity_id && !checkingAvailability}
+                  disabled={disabled}
+                  changed={changes?.entity_id ? true : null}
+                  isloading={values.entity_id && values.entity_id !== checkedId && checkingAvailability ? 1 : 0}
+                />
+              </InputRow>
+            );
+
+          case 'metadata_url':
+            return (
+              <InputRow
+                key={fieldName}
+                title={t('form_metadata_url')}
+                moreInfo={tenant.form_config.more_info?.metadata_url || {}}
+                required={true}
+                description={t('form_metadata_url_desc')}
+                error={metadataAsyncError || errors.metadata_url}
+                touched={touched.metadata_url}
+              >
+                <MetadataInput
+                  name="metadata_url"
+                  placeholder="Type something"
+                  onChange={(e) => {
+                    setMetadataAyncError('');
+                    setMetadataWarning();
+                    handleChange(e);
+                  }}
+                  value={values.metadata_url}
+                  isInvalid={!!metadataAsyncError || !!errors.metadata_url}
+                  onBlur={() => {}}
+                  disabled={disabled}
+                  getmetadata={(metadata_url) => {
+                    getMetadata(metadata_url, null, (attributes) => {
+                      setFieldValue('requested_attributes', attributes, false);
+                    });
+                  }}
+                  changed={changes?.metadata_url ? true : null}
+                />
+                <UrlWarning url={values.metadata_url} overwriteWarning={metadataWarning} disableCheck={1} touched={!!values.metadata_url} />
+              </InputRow>
+            );
+
+          case 'requested_attributes':
+            if (tenant.form_config.more_info.requested_attributes?.disabled) return null;
+            return (
+              <InputRow
+                key={fieldName}
+                title={tenant.form_config.more_info.requested_attributes.label || 'Attributes'}
+                moreInfo={tenant.form_config.more_info.requested_attributes || {}}
+                required={false}
+                description={tenant.form_config.more_info.requested_attributes.description}
+                error={errors.requested_attributes}
+                touched={touched.requested_attributes}
+              >
+                <SamlAttributesInput
+                  name="requested_attributes"
+                  values={values.requested_attributes || []}
+                  placeholder={t('form_type_prompt')}
+                  defaultValues={tenant.form_config.requested_attributes}
+                  errors={errors.requested_attributes}
+                  touched={touched.requested_attributes}
+                  setMetadataLoaded={setMetadataLoaded}
+                  disabled={disabled}
+                  setFieldValue={setFieldValue}
+                  onBlur={() => {}}
+                  changed={changes?.requested_attributes ? true : null}
+                />
+              </InputRow>
+            );
+
+          default:
+            return null;
+        }
+      })}
+    </div>
+  );
+};
+
+export default SamlFields;

--- a/federation-registry-frontend/src/Components/ServiceFormTabs.js
+++ b/federation-registry-frontend/src/Components/ServiceFormTabs.js
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import Tabs from 'react-bootstrap/Tabs';
+import Tab from 'react-bootstrap/Tab';
+import { useTranslation } from 'react-i18next';
+import { TabConfigProvider, useTabConfig } from './TabConfigProvider';
+import GeneralTab from './GeneralTab';
+import ProtocolTab from './ProtocolTab';
+
+/**
+ * Default tab configuration.
+ * Override by passing custom tabs prop to ServiceFormTabs.
+ */
+const defaultTabs = [
+  {
+    key: 'general',
+    titleKey: 'form_tab_general',
+    order: 1,
+    visibleIf: null
+  },
+  {
+    key: 'protocol',
+    titleKey: 'form_tab_protocol',
+    order: 2,
+    visibleIf: null
+  }
+];
+
+/**
+ * Internal tab component renderer.
+ * Uses a map to associate tab keys with their components.
+ */
+const tabComponents = {
+  general: GeneralTab,
+  protocol: ProtocolTab
+};
+
+/**
+ * Inner tabs component that uses the context.
+ */
+const ServiceFormTabsInner = ({ disabled, changes, extraFields }) => {
+  const { t } = useTranslation();
+  const { getSortedTabs, isTabVisible } = useTabConfig();
+  const [activeKey, setActiveKey] = useState('general');
+
+  const sortedTabs = getSortedTabs();
+
+  return (
+    <Tabs
+      activeKey={activeKey}
+      onSelect={(key) => setActiveKey(key)}
+      className="form-tabs"
+      id="service-form-tabs"
+    >
+      {sortedTabs.map((tab) => {
+        // Check visibility condition
+        if (!isTabVisible(tab.visibleIf)) {
+          return null;
+        }
+
+        const Component = tabComponents[tab.key];
+        const title = t(tab.titleKey);
+
+        if (!Component) {
+          return null;
+        }
+
+        return (
+          <Tab eventKey={tab.key} title={title} key={tab.key}>
+            <Component
+              disabled={disabled}
+              changes={changes}
+              extraFields={extraFields}
+            />
+          </Tab>
+        );
+      })}
+    </Tabs>
+  );
+};
+
+/**
+ * Main service form tabs component.
+ * Wraps tabs in a config provider for extensibility.
+ *
+ * @param {Object} props
+ * @param {boolean} props.disabled - Whether the form is disabled
+ * @param {Object} props.changes - Changes object for tracking modifications
+ * @param {Object} props.extraFields - Extra fields from tenant config
+ * @param {Array} props.tabs - Optional custom tabs configuration
+ * @param {Object} props.fields - Optional custom fields_by_tab configuration
+ */
+const ServiceFormTabs = ({ disabled, changes, extraFields, tabs, fields }) => {
+  const tabsConfig = tabs || defaultTabs;
+
+  return (
+    <TabConfigProvider tabs={tabsConfig} fields={fields}>
+      <div className="form-tabs-container">
+        <ServiceFormTabsInner
+          disabled={disabled}
+          changes={changes}
+          extraFields={extraFields}
+        />
+      </div>
+    </TabConfigProvider>
+  );
+};
+
+export default ServiceFormTabs;
+
+/**
+ * Example: Customizing field order in form_field_config.json:
+ *
+ * "field_order": {
+ *   "general": [
+ *     { "field": "service_name", "order": 1, "required": true },
+ *     { "field": "contacts", "order": 2, "required": true },
+ *     { "field": "logo_uri", "order": 3, "required": false },
+ *     ...
+ *   ],
+ *   "protocol": {
+ *     "oidc": [
+ *       { "field": "application_type", "order": 1, "required": true },
+ *       { "field": "grant_types", "order": 2, "required": false },
+ *       ...
+ *     ],
+ *     "saml": [
+ *       { "field": "entity_id", "order": 1, "required": true },
+ *       { "field": "metadata_url", "order": 2, "required": true },
+ *       ...
+ *     ]
+ *   }
+ * }
+ *
+ * Example: Conditional field visibility:
+ *
+ * {
+ *   "field": "client_secret",
+ *   "order": 5,
+ *   "condition": "token_endpoint_auth_method !== 'private_key_jwt' && token_endpoint_auth_method !== 'none'"
+ * }
+ *
+ * Example: Programmatic reordering:
+ *
+ * const { reorderFields } = useTabConfig();
+ * const reordered = reorderFields('general', ['contacts', 'service_name', 'logo_uri']);
+ */

--- a/federation-registry-frontend/src/Components/TabConfigProvider.js
+++ b/federation-registry-frontend/src/Components/TabConfigProvider.js
@@ -1,0 +1,272 @@
+import React, { createContext, useContext } from 'react';
+
+/**
+ * Default configuration - used when form_field_config.json is missing or invalid.
+ * This ensures backwards compatibility with the original field ordering.
+ */
+const DEFAULT_CONFIG = {
+  tabs: [
+    { key: 'general', titleKey: 'form_tab_general', order: 1, visibleIf: null },
+    { key: 'protocol', titleKey: 'form_tab_protocol', order: 2, visibleIf: null }
+  ],
+  fields_by_tab: {
+    general: [
+      'service_name',
+      'integration_environment',
+      'logo_uri',
+      'website_url',
+      'service_description',
+      'country',
+      'policy_uri',
+      'contacts'
+    ],
+    protocol: [
+      'protocol',
+      'application_type',
+      'grant_types',
+      'token_endpoint_auth_method',
+      'client_secret',
+      'token_endpoint_auth_signing_alg',
+      'jwks',
+      'jwks_uri',
+      'allow_introspection',
+      'scope',
+      'redirect_uris',
+      'post_logout_redirect_uris',
+      'code_challenge_method',
+      'refresh_token_validity_seconds',
+      'device_code_validity_seconds',
+      'access_token_validation_model',
+      'access_token_validity_seconds',
+      'id_token_timeout_seconds',
+      'entity_id',
+      'metadata_url',
+      'requested_attributes'
+    ]
+  },
+  field_order: {
+    general: [
+      { field: 'service_name', order: 1, required: true },
+      { field: 'integration_environment', order: 2, required: true },
+      { field: 'logo_uri', order: 3, required: false },
+      { field: 'website_url', order: 4, required: false },
+      { field: 'service_description', order: 5, required: true },
+      { field: 'country', order: 6, required: false },
+      { field: 'policy_uri', order: 7, required: false },
+      { field: 'contacts', order: 8, required: true }
+    ],
+    protocol: {
+      oidc: [
+        { field: 'protocol', order: 1, required: true },
+        { field: 'application_type', order: 2, required: true },
+        { field: 'grant_types', order: 3, required: false },
+        { field: 'token_endpoint_auth_method', order: 4, required: true },
+        { field: 'client_secret', order: 5, required: false },
+        { field: 'token_endpoint_auth_signing_alg', order: 6, required: false },
+        { field: 'jwks', order: 7, required: false },
+        { field: 'jwks_uri', order: 8, required: false },
+        { field: 'allow_introspection', order: 9, required: false },
+        { field: 'scope', order: 10, required: false },
+        { field: 'redirect_uris', order: 11, required: false },
+        { field: 'post_logout_redirect_uris', order: 12, required: false },
+        { field: 'code_challenge_method', order: 13, required: true },
+        { field: 'refresh_token_validity_seconds', order: 14, required: false },
+        { field: 'device_code_validity_seconds', order: 15, required: false },
+        { field: 'access_token_validation_model', order: 16, required: true },
+        { field: 'access_token_validity_seconds', order: 17, required: true },
+        { field: 'id_token_timeout_seconds', order: 18, required: true }
+      ],
+      saml: [
+        { field: 'protocol', order: 1, required: true },
+        { field: 'entity_id', order: 2, required: true },
+        { field: 'metadata_url', order: 3, required: true },
+        { field: 'requested_attributes', order: 4, required: false }
+      ]
+    }
+  }
+};
+
+let formFieldConfig;
+try {
+  // eslint-disable-next-line no-unused-vars
+  const loadedConfig = require('../form_field_config.json');
+  formFieldConfig = loadedConfig;
+} catch {
+  // Config file missing or invalid - use defaults for backwards compatibility
+  formFieldConfig = DEFAULT_CONFIG;
+}
+
+const TabConfigContext = createContext(null);
+
+/**
+ * Configuration-driven tab and field management.
+ * Enables custom ordering and field mapping via form_field_config.json.
+ * Falls back to default order if config is missing (backwards compatible).
+ */
+export const TabConfigProvider = ({ tabs, fields, children }) => {
+  // Use provided config or fall back to defaults
+  const configTabs = tabs || formFieldConfig.tabs;
+  const configFields = fields || formFieldConfig.fields_by_tab;
+  const configFieldOrder = formFieldConfig.field_order || {};
+
+  /**
+   * Get tabs sorted by their order property.
+   * @returns {Array} Sorted tab configurations
+   */
+  const getSortedTabs = () => {
+    return [...configTabs].sort((a, b) => (a.order ?? 999) - (b.order ?? 999));
+  };
+
+  /**
+   * Get fields for a specific tab, sorted by order.
+   * @param {string} tabKey - The tab identifier
+   * @returns {Array} Array of field configurations sorted by order
+   */
+  const getFieldsForTab = (tabKey) => {
+    const fields = configFields[tabKey] || [];
+    const orderConfig = configFieldOrder[tabKey] || [];
+
+    // Create a map of field -> order
+    const orderMap = {};
+    if (Array.isArray(orderConfig)) {
+      orderConfig.forEach((item) => {
+        orderMap[item.field] = item.order ?? 999;
+      });
+    }
+
+    // Sort fields by their order
+    return [...fields].sort((a, b) => {
+      const orderA = orderMap[a] ?? 999;
+      const orderB = orderMap[b] ?? 999;
+      return orderA - orderB;
+    });
+  };
+
+  /**
+   * Get field configuration (order, required, condition) for a specific field.
+   * @param {string} tabKey - The tab identifier
+   * @param {string} fieldName - The field name
+   * @returns {Object|null} Field configuration or null
+   */
+  const getFieldConfig = (tabKey, fieldName) => {
+    const orderConfig = configFieldOrder[tabKey];
+    if (!orderConfig) return null;
+
+    // Handle protocol-specific configs (oidc/saml)
+    if (typeof orderConfig === 'object' && !Array.isArray(orderConfig)) {
+      for (const protocol of Object.keys(orderConfig)) {
+        const found = orderConfig[protocol].find((f) => f.field === fieldName);
+        if (found) return found;
+      }
+      return null;
+    }
+
+    return orderConfig.find((f) => f.field === fieldName) || null;
+  };
+
+  /**
+   * Check if a field should be visible based on its condition.
+   * @param {string|null} condition - Condition expression or null for always visible
+   * @param {Object} context - Context variables for condition evaluation
+   * @returns {boolean}
+   */
+  const isFieldVisible = (condition, context = {}) => {
+    if (!condition) return true;
+    try {
+      const fn = new Function(...Object.keys(context), `return ${condition}`);
+      return fn(...Object.values(context));
+    } catch {
+      return false;
+    }
+  };
+
+  /**
+   * Check if a tab should be visible based on condition.
+   * @param {string|null} visibleIf - Condition expression or null for always visible
+   * @param {Object} context - Context variables for condition evaluation
+   * @returns {boolean}
+   */
+  const isTabVisible = (visibleIf, context = {}) => {
+    if (!visibleIf) return true;
+    return isFieldVisible(visibleIf, context);
+  };
+
+  /**
+   * Reorder tabs based on custom order array.
+   * @param {Array<string>} tabKeys - Array of tab keys in desired order
+   * @returns {Array} Reordered tabs
+   */
+  const reorderTabs = (tabKeys) => {
+    const tabMap = {};
+    configTabs.forEach((tab) => {
+      tabMap[tab.key] = tab;
+    });
+
+    const result = [];
+    tabKeys.forEach((key) => {
+      if (tabMap[key]) {
+        result.push(tabMap[key]);
+      }
+    });
+
+    // Add any remaining tabs not in the custom order
+    configTabs.forEach((tab) => {
+      if (!tabKeys.includes(tab.key)) {
+        result.push(tab);
+      }
+    });
+
+    return result;
+  };
+
+  /**
+   * Reorder fields within a tab based on custom order array.
+   * @param {string} tabKey - The tab identifier
+   * @param {Array<string>} fieldNames - Array of field names in desired order
+   * @returns {Array} Reordered fields
+   */
+  const reorderFields = (tabKey, fieldNames) => {
+    const fields = getFieldsForTab(tabKey);
+    const fieldSet = new Set(fields);
+
+    const result = [];
+    fieldNames.forEach((name) => {
+      if (fieldSet.has(name)) {
+        result.push(name);
+      }
+    });
+
+    fields.forEach((field) => {
+      if (!fieldNames.includes(field)) {
+        result.push(field);
+      }
+    });
+
+    return result;
+  };
+
+  return (
+    <TabConfigContext.Provider
+      value={{
+        getSortedTabs,
+        getFieldsForTab,
+        getFieldConfig,
+        isTabVisible,
+        isFieldVisible,
+        reorderTabs,
+        reorderFields,
+        rawConfig: formFieldConfig
+      }}
+    >
+      {children}
+    </TabConfigContext.Provider>
+  );
+};
+
+export const useTabConfig = () => {
+  const context = useContext(TabConfigContext);
+  if (!context) {
+    throw new Error('useTabConfig must be used within TabConfigProvider');
+  }
+  return context;
+};

--- a/federation-registry-frontend/src/Components/UrlWarning.js
+++ b/federation-registry-frontend/src/Components/UrlWarning.js
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { reg } from '../regex';
+
+var urlCheckTimeout;
+var urlCheckTimeoutResponse;
+
+/**
+ * URL Warning component - displays a warning when a URL doesn't seem to exist.
+ */
+export const UrlWarning = (props) => {
+  const [active, setActive] = useState(!!props.overwriteWarning);
+
+  useEffect(() => {
+    if (!props.overwriteWarning) {
+      setActive(false);
+      clearTimeout(urlCheckTimeout);
+      if (props.touched && props.url && reg.regSimpleUrl.test(props.url)) {
+        const exists = async (url) => {
+          const result = await fetch(url, {
+            method: 'HEAD',
+            mode: 'no-cors'
+          });
+          return result.ok;
+        };
+        urlCheckTimeout = setTimeout(() => {
+          urlCheckTimeoutResponse = setTimeout(() => {
+            setActive(true);
+            clearTimeout(urlCheckTimeout);
+          }, 3000);
+          exists(props.url)
+            .then((result) => {
+              clearTimeout(urlCheckTimeoutResponse);
+              setActive(false);
+            })
+            .catch((err) => {
+              clearTimeout(urlCheckTimeoutResponse);
+              setActive(true);
+            });
+        }, 1000);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.url, props.touched]);
+
+  return (
+    <React.Fragment>
+      {(active && !props.disableCheck) || props.overwriteWarning ? (
+        <div className="pkce-tooltip">
+          <FontAwesomeIcon icon={faExclamationTriangle} />
+          {props.overwriteWarning
+            ? props.overwriteWarning
+            : "The provided url does not seem to exist"}
+        </div>
+      ) : null}
+    </React.Fragment>
+  );
+};
+
+export default UrlWarning;

--- a/federation-registry-frontend/src/ServiceForm.js
+++ b/federation-registry-frontend/src/ServiceForm.js
@@ -2,43 +2,35 @@ import React, { useState, useEffect, useContext, useRef } from 'react';
 import mapValues from 'lodash/mapValues';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheckCircle, faBan, faSortDown, faExclamationTriangle, faPen } from '@fortawesome/free-solid-svg-icons';
-import Tabs from 'react-bootstrap/Tabs';
-import Tab from 'react-bootstrap/Tab';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
-import CopyDialog from './Components/CopyDialog.js'
+import CopyDialog from './Components/CopyDialog.js';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Row from 'react-bootstrap/Row';
 import { ProcessingRequest } from './Components/LoadingBar';
-import Col from 'react-bootstrap/Col';
 import Collapse from 'react-bootstrap/Collapse';
-import { useParams } from "react-router-dom";
+import { useParams } from 'react-router-dom';
 import { diff } from 'deep-diff';
 import { tenantContext } from './context.js';
 import Alert from 'react-bootstrap/Alert';
-// import {Debug} from './Components/Debug.js';
 import { SimpleModal, Logout, NotFound, PetitionSubmittedModal } from './Components/Modals.js';
 import Form from 'react-bootstrap/Form';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import {formatDuration} from './helpers.js';
 import { Formik } from 'formik';
 import config from './config.json';
-import InputRow from './Components/InputRow.js';
 import Button from 'react-bootstrap/Button';
 import ManageTags from './Components/ManageTags.js';
 import * as yup from 'yup';
 import { useTranslation } from 'react-i18next';
 import parse from 'html-react-parser';
 import countryData from 'country-region-data';
-import { SimpleInput, AccessTokenValidationModel, CountrySelect, AuthMethRadioList, SelectEnvironment, DeviceCode, Select, PublicKey, ListInput, LogoInput, TextAria, ListInputArray, CheckboxList, SimpleCheckbox, ClientSecret, TimeInput, RefreshToken, Contacts, OrganizationField, SimpleRadio, MetadataInput } from './Components/Inputs.js'// eslint-disable-next-line
-import { SamlAttributesInput } from './Components/SamlAttributes.js';
-import { ConfirmationModal } from './Components/Modals';
-import MoveDialog from "./Components/MoveDialog";
-
-
-
+import InputRow from './Components/InputRow.js';
+import { SimpleInput, SimpleCheckbox } from './Components/Inputs.js';
+import MoveDialog from './Components/MoveDialog';
+import ServiceFormTabs from './Components/ServiceFormTabs';
 
 const { reg } = require('./regex.js');
+
 var availabilityCheckTimeout;
 var urlCheckTimeout;
 var urlCheckTimeoutResponse;
@@ -47,18 +39,18 @@ let integrationEnvironment;
 let application_type;
 let timeouts = {};
 
-// Updated by Jan Pavlíček (xpavli95@stud.fit.vutbr.cz) - to show move dialog instead of copy dialog when clicking
-// the button next to the integration environments box.
+/**
+ * ServiceForm - Main service configuration form component.
+ * Uses extracted tab components for better separation of concerns.
+ */
 const ServiceForm = (props) => {
-
-  // eslint-disable-next-line
   const { t, i18n } = useTranslation();
   let { tenant_name } = useParams();
   let { service_id } = useParams();
   let { petition_id } = useParams();
+
   const [notFound, setNotFound] = useState(false);
   const [restrictReview, setRestrictReview] = useState(false);
-  // eslint-disable-next-line
   const [tenant, setTenant] = useContext(tenantContext);
   const [logout, setLogout] = useState(false);
   const [submitDisabled, setSubmitDisabled] = useState(false);
@@ -74,17 +66,16 @@ const ServiceForm = (props) => {
     entity_id: null,
     metadata_url: null
   });
-  const [metadataAsyncError, setMetadataAyncError] = useState("");
+  const [metadataAsyncError, setMetadataAyncError] = useState('');
   const [metadataChecked, setMetadataChecked] = useState();
-  const [metadataLoading, setMetadataLoading] = useState(false)
+  const [metadataLoading, setMetadataLoading] = useState(false);
   const [checkingAvailability, setCheckingAvailability] = useState(false);
-  const [checkedId, setCheckedId] = useState(); // Variable containing the last client Id checked for availability to limit check requests
-  // const [loadedMetadata,setLoadedMetadata] = useState(); // Variable containing the last loaded metadata url
+  const [checkedId, setCheckedId] = useState();
   const [checkedEnvironment, setCheckedEnvironment] = useState();
   const [asyncResponse, setAsyncResponse] = useState(false);
   const [formValues, setFormValues] = useState();
   const [showCopyDialog, setShowCopyDialog] = useState(false);
-  const [showMoveDialog,setShowMoveDialog] = useState(false);
+  const [showMoveDialog, setShowMoveDialog] = useState(false);
   const [showInitErrors, setShowInitErrors] = useState(false);
   const [logoWarning, setLogoWarning] = useState(false);
   const [serviceTags, setServiceTags] = useState([]);
@@ -95,453 +86,718 @@ const ServiceForm = (props) => {
   const serviceMoveEnabled = tenant?.config?.merge_environments_on_deploy ?? false;
 
   useEffect(() => {
-    //Get tags 
     if (props.user.actions.includes('manage_tags') && service_id) {
       getTags();
     }
 
     countries = [];
     if (service_id || petition_id) {
-      setShowInitErrors(true)
+      setShowInitErrors(true);
     }
 
-    if (!tenant.form_config.integration_environment.includes(props.initialValues.integration_environment)) {
-      props.initialValues.integration_environment = tenant.form_config.integration_environment[0];
+    if (
+      !tenant.form_config.integration_environment.includes(props.initialValues.integration_environment)
+    ) {
+      props.initialValues.integration_environment =
+        tenant.form_config.integration_environment[0];
     }
 
     if (props.move_service && props.integration_environment) {
       props.initialValues.integration_environment = props.integration_environment;
     }
 
-    countryData.forEach((item, index) => {
+    countryData.forEach((item) => {
       countries.push(item.countryShortCode.toLowerCase());
-
     });
+
     if (props.disabled || props.review) {
       setDisabled(true);
     }
+
     let extra_fields = tenant.form_config.extra_fields;
-    Object.keys(extra_fields).forEach((name, index) => {
+    Object.keys(extra_fields).forEach((name) => {
       if (!Object.keys(props.initialValues).includes(name)) {
         props.initialValues[name] = extra_fields[name].default;
       }
     });
 
-    // Check restrictions for review
     if (props.review) {
-      if (tenant.restricted_environments.includes(props.initialValues.integration_environment) && !props.user.actions.includes('review_restricted')) {
+      if (
+        tenant.restricted_environments.includes(props.initialValues.integration_environment) &&
+        !props.user.actions.includes('review_restricted')
+      ) {
         setRestrictReview(true);
       }
     }
+
     if (props.initialValues.organization_name) {
       setDisabledOrganizationFields(['organization_url']);
     }
+
     setFormValues(props.initialValues);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.initialValues]);
 
-
-  // Returns true
-  yup.addMethod(yup.array, 'unique', function (message, mapper = a => a) {
+  yup.addMethod(yup.array, 'unique', function (message, mapper = (a) => a) {
     return this.test('unique', message, function (list) {
       if (list) {
         return list.length === new Set(list.map(mapper)).size;
-      }
-      else {
+      } else {
         return true;
       }
     });
   });
+
   function imageExists(url) {
     if (url) {
       var img = new Image();
-      img.onload = function () { setLogoWarning(false); };
-      img.onerror = function () { setLogoWarning(true); };
+      img.onload = function () {
+        setLogoWarning(false);
+      };
+      img.onerror = function () {
+        setLogoWarning(true);
+      };
       img.src = url;
-
-    }
-    else {
+    } else {
       setLogoWarning(false);
     }
   }
 
   const dynamicValidation = async (values, props) => {
     let error = {};
-    lazy_schema.validate(values, { abortEarly: false }).catch(function (err) {
-      if (err.inner) {
-        err.inner.forEach(item => {
-          error[item.path] = item.message;
-        })
-      }
-    });
+    lazy_schema
+      .validate(values, { abortEarly: false })
+      .catch(function (err) {
+        if (err.inner) {
+          err.inner.forEach((item) => {
+            error[item.path] = item.message;
+          });
+        }
+      });
     return error;
-  }
-
+  };
 
   const getMetadata = async (value, resolve, setRequestedAttributes) => {
     setMetadataLoading(true);
     setMetadataAyncError();
     setMetadataChecked(value);
-    let loadMetadata = !(metadataChecked !== value && value !== metadataLoaded.metadata_url && value !== props.initialValues.metadataUrl) || setRequestedAttributes
-    clearTimeout(timeouts[timeoutId])
+    let loadMetadata =
+      !(
+        metadataChecked !== value &&
+        value !== metadataLoaded.metadata_url &&
+        value !== props.initialValues.metadataUrl
+      ) || setRequestedAttributes;
+
+    clearTimeout(timeouts[timeoutId]);
     timeouts[timeoutId] = setTimeout(() => {
-      fetch(config.host[tenant_name] + 'util/metadata_info?metadata_url=' + encodeURIComponent(value), {
-        method: 'GET',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }).then(async response => {
-        if (response.status === 200 || response.status === 304) {
-          let metadata = await response.json();
-          if (tenant.form_config.more_info.requested_attributes && !tenant.form_config.more_info.requested_attributes.disabled) {
-            loadMetadata && setMetadataLoaded(metadata);
-            if (metadata.supported_attributes.length === 0 && !metadata.entity_id) {
-              if (!resolve) {
-                setRequestedAttributes(tenant.form_config.requested_attributes);
-              }
-              setMetadataWarning('Could not find an Entity Id or any Requested Attributes from this Metadata Url.');
-            }
-            else if (metadata.supported_attributes.length === 0) {
-              if (!resolve) {
-                setRequestedAttributes(tenant.form_config.defaultValues.requested_attributes);
-              }
-              setMetadataWarning('Could not find any Requested Attributes from this Metadata Url.');
-            }
-            else if (!metadata.entity_id) {
-              setMetadataWarning('Could not find an Entity Id from this Metadata Url.');
-            }
+      fetch(
+        config.host[tenant_name] +
+          'util/metadata_info?metadata_url=' +
+          encodeURIComponent(value),
+        {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json'
           }
-          else {
+        }
+      )
+        .then(async (response) => {
+          if (response.status === 200 || response.status === 304) {
+            let metadata = await response.json();
+            if (
+              tenant.form_config.more_info.requested_attributes &&
+              !tenant.form_config.more_info.requested_attributes.disabled
+            ) {
+              loadMetadata && setMetadataLoaded(metadata);
+              if (
+                metadata.supported_attributes.length === 0 &&
+                !metadata.entity_id
+              ) {
+                if (!resolve) {
+                  setRequestedAttributes(tenant.form_config.requested_attributes);
+                }
+                setMetadataWarning(
+                  'Could not find an Entity Id or any Requested Attributes from this Metadata Url.'
+                );
+              } else if (metadata.supported_attributes.length === 0) {
+                if (!resolve) {
+                  setRequestedAttributes(
+                    tenant.form_config.defaultValues.requested_attributes
+                  );
+                }
+                setMetadataWarning(
+                  'Could not find any Requested Attributes from this Metadata Url.'
+                );
+              } else if (!metadata.entity_id) {
+                setMetadataWarning(
+                  'Could not find an Entity Id from this Metadata Url.'
+                );
+              }
+            } else {
+              if (!resolve) {
+                setRequestedAttributes(
+                  tenant.form_config.defaultValues.requested_attributes
+                );
+              }
+              metadata.supported_attributes = [];
+              loadMetadata && setMetadataLoaded(metadata);
+            }
+          } else {
             if (!resolve) {
-              setRequestedAttributes(tenant.form_config.defaultValues.requested_attributes);
+              setRequestedAttributes(
+                tenant.form_config.defaultValues.requested_attributes
+              );
             }
-            metadata.supported_attributes = [];
-
-            loadMetadata && setMetadataLoaded(metadata);
+            setMetadataAyncError(response.statusText);
           }
-        }
-        else {
-          if (!resolve) {
-            setRequestedAttributes(tenant.form_config.defaultValues.requested_attributes);
+          setMetadataLoading(false);
+        })
+        .catch(() => {
+          setMetadataLoading(false);
+          setMetadataAyncError('Could not get response from Metadata url');
+          if (resolve) {
+            resolve(true);
           }
-          setMetadataAyncError(response.statusText);
-        }
-        setMetadataLoading(false);
-      }).catch(() => {
-        setMetadataLoading(false);
-        setMetadataAyncError("Could not get response from Metadata Url");
-        if (resolve) {
-          resolve(true)
-        }
-      });
+        });
     }, 2000);
-  }
+  };
 
-
-  const lazy_schema = yup.lazy(obj => yup.object(
-    mapValues(obj, (v, k) => {
-      if (Object.keys((tenant.form_config.extra_fields)).includes(k) && tenant.form_config.extra_fields[k].type === 'boolean') {
-        return yup.boolean().required(t('yup_required')).when('integration_environment', {
-          is: (integration_environment) => { return tenant.form_config.extra_fields[k].required.includes(integration_environment) },
-          then: yup.boolean().oneOf([true], tenant.form_config.extra_fields[k].error)
-        })
-      }
-      else if (Object.keys((tenant.form_config.extra_fields)).includes(k) && k === 'aup_uri') {
-        return yup.string().nullable().test('testAvailable', t('yup_url'), function (value) {
-          if (!value) {
-            return true
-          }
-          else {
-            return value.match(reg.regSimpleUrl)
-          }
-        }).when('integration_environment', {
-          is: (integration_environment) => tenant.form_config.extra_fields[k].required.includes(integration_environment),
-          then: yup.string().nullable().required(t('yup_required'))
-        })
-      }
-    })
-  ));
+  const lazy_schema = yup.lazy((obj) =>
+    yup.object(
+      mapValues(obj, (v, k) => {
+        if (
+          Object.keys(tenant.form_config.extra_fields).includes(k) &&
+          tenant.form_config.extra_fields[k].type === 'boolean'
+        ) {
+          return yup.boolean().required(t('yup_required')).when('integration_environment', {
+            is: (integration_environment) => {
+              return tenant.form_config.extra_fields[k].required.includes(
+                integration_environment
+              );
+            },
+            then: yup.boolean().oneOf([true], tenant.form_config.extra_fields[k].error)
+          });
+        } else if (
+          Object.keys(tenant.form_config.extra_fields).includes(k) &&
+          k === 'aup_uri'
+        ) {
+          return yup
+            .string()
+            .nullable()
+            .test('testAvailable', t('yup_url'), function (value) {
+              if (!value) {
+                return true;
+              } else {
+                return value.match(reg.regSimpleUrl);
+              }
+            })
+            .when('integration_environment', {
+              is: (integration_environment) =>
+                tenant.form_config.extra_fields[k].required.includes(
+                  integration_environment
+                ),
+              then: yup.string().nullable().required(t('yup_required'))
+            });
+        }
+      })
+    )
+  );
 
   const schema = yup.object({
-    service_name: yup.string().nullable().min(4, t('yup_char_min') + ' (' + 2 + ')').max(256, t('yup_char_max') + ' (' + 256 + ')').required(t('yup_required')),
-    // Every time client_id changes we make a fetch request to see if it is available.
-    policy_uri: yup.string().nullable().when('integration_environment', {
-      is: (integrationEnvironment) => tenant.form_config.more_info.policy_uri?.required?.includes(integrationEnvironment),
-      then: yup.string().nullable().required(t('yup_required')).matches(reg.regSimpleUrl, t('yup_url')),
-      otherwise: yup.string().nullable().matches(reg.regSimpleUrl, t('yup_url'))
-    }),
+    service_name: yup
+      .string()
+      .nullable()
+      .min(4, t('yup_char_min') + ' (' + 2 + ')')
+      .max(256, t('yup_char_max') + ' (' + 256 + ')')
+      .required(t('yup_required')),
+    policy_uri: yup
+      .string()
+      .nullable()
+      .when('integration_environment', {
+        is: (integrationEnvironment) =>
+          tenant.form_config.more_info.policy_uri?.required?.includes(
+            integrationEnvironment
+          ),
+        then: yup
+          .string()
+          .nullable()
+          .required(t('yup_required'))
+          .matches(reg.regSimpleUrl, t('yup_url')),
+        otherwise: yup.string().nullable().matches(reg.regSimpleUrl, t('yup_url'))
+      }),
     website_url: yup.string().nullable().matches(reg.regSimpleUrl, t('yup_url')),
-    client_id: yup.string().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.string().nullable().min(2, t('yup_char_min') + ' (' + 2 + ')').max(128, t('yup_char_max') + ' (' + 128 + ')').matches(reg.regClientId, 'Client Id can contain only numbers, letters and the special characters  "$-_.+!*\'(),"').test('testAvailable', t('yup_client_id_available'), function (value) {
-        if (props.initialValues.client_id === value && !props.copy) {
-          return true
-        }
-        else {
-          return new Promise((resolve, reject) => {
-            clearTimeout(availabilityCheckTimeout);
-            if (!value) { resolve(true) }
-            else {
-              if (value === checkedId && formRef.current.values.integration_environment === checkedEnvironment) {
-                resolve(availabilityCheck);
-              }
-              else {
-                setCheckingAvailability(true);
-                availabilityCheckTimeout = setTimeout(() => {
-                  fetch(config.host[tenant_name] + 'tenants/' + tenant_name + '/check-availability?value=' + value + '&protocol=oidc&environment=' + this.parent.integration_environment + (petition_id ? ('&petition_id=' + petition_id) : "") + (service_id ? ('&service_id=' + service_id) : ""), {
-                    method: 'GET',
-                    credentials: 'include',
-                    headers: {
-                      'Content-Type': 'application/json'
-                    }
-                  }).then(response => {
-                    if (response.status === 200 || response.status === 304) {
-                      return response.json();
-                    }
-                    else {
-                      return false
-                    }
-                  }).then(response => {
-                    setCheckedId(value);
-                    setCheckingAvailability(false);
-                    setCheckedEnvironment(this.parent.integration_environment);
-                    if (response) {
-                      setCheckedId(value);
-                      setAvailabilityCheck(response.available);
-                      resolve(response.available)
-                    }
-                    else {
-                      resolve(false);
-                    }
+    client_id: yup
+      .string()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .string()
+          .nullable()
+          .min(4, t('yup_char_min') + ' (' + 2 + ')')
+          .max(128, t('yup_char_max') + ' (' + 128 + ')')
+          .matches(
+            reg.regClientId,
+            "Client Id can contain only numbers, letters and the special characters \"$-_.+!*'(),\""
+          )
+          .test('testAvailable', t('yup_client_id_available'), function (value) {
+            if (props.initialValues.client_id === value && !props.copy) {
+              return true;
+            } else {
+              return new Promise((resolve, reject) => {
+                clearTimeout(availabilityCheckTimeout);
+                if (!value) {
+                  resolve(true);
+                } else {
+                  if (
+                    value === checkedId &&
+                    formRef.current.values.integration_environment ===
+                      checkedEnvironment
+                  ) {
+                    resolve(availabilityCheck);
+                  } else {
+                    setCheckingAvailability(true);
+                    availabilityCheckTimeout = setTimeout(() => {
+                      fetch(
+                        config.host[tenant_name] +
+                          'tenants/' +
+                          tenant_name +
+                          '/check-availability?value=' +
+                          value +
+                          '&protocol=oidc&environment=' +
+                          this.parent.integration_environment +
+                          (petition_id ? '&petition_id=' + petition_id : '') +
+                          (service_id ? '&service_id=' + service_id : ''),
+                        {
+                          method: 'GET',
+                          credentials: 'include',
+                          headers: {
+                            'Content-Type': 'application/json'
+                          }
+                        }
+                      )
+                        .then((response) => {
+                          if (response.status === 200 || response.status === 304) {
+                            return response.json();
+                          } else {
+                            return false;
+                          }
+                        })
+                        .then((response) => {
+                          setCheckedId(value);
+                          setCheckingAvailability(false);
+                          setCheckedEnvironment(this.parent.integration_environment);
+                          if (response) {
+                            setCheckedId(value);
+                            setAvailabilityCheck(response.available);
+                            resolve(response.available);
+                          } else {
+                            resolve(false);
+                          }
+                        })
+                        .catch(() => {
+                          resolve(true);
+                        });
+                    }, 1000);
                   }
-                  ).catch(() => { resolve(true) });
-                }, 1000);
-              }
+                }
+              });
             }
           })
+      }),
+    redirect_uris: yup
+      .array()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .array()
+          .nullable()
+          .when('integration_environment', (integration_environment) => {
+            integrationEnvironment = integration_environment;
+          })
+          .when('application_type', (application_type_value) => {
+            application_type = application_type_value;
+          })
+          .of(
+            yup
+              .string()
+              .required("Uri can't be an empty string")
+              .test('test_redirect_uri', 'Invalid Redirect Uri', function (value) {
+                if (value) {
+                  let url;
+                  if (tenant?.config?.test_env.includes(integrationEnvironment)) {
+                    let isLocalIp =
+                      reg.regIpv4Local.test(value) || reg.regIpv6Local.test(value);
+                    if (isLocalIp) {
+                      return true;
+                    }
+                  }
+                  try {
+                    url = new URL(value);
+                  } catch (err) {
+                    return this.createError({ message: 'Invalid uri' });
+                  }
+                  if (value.includes('#')) {
+                    return this.createError({
+                      message: "Uri can't contain fragments"
+                    });
+                  }
+                  if (application_type === 'WEB') {
+                    if (!tenant?.config?.test_env.includes(integrationEnvironment)) {
+                      if (
+                        url.protocol !== 'https:' &&
+                        !(url.protocol === 'http:' && url.hostname === 'localhost')
+                      ) {
+                        return this.createError({
+                          message:
+                            'Uri must be a secure url starting with https://'
+                        });
+                      }
+                    } else {
+                      if (
+                        url &&
+                        !(url.protocol === 'http:' || url.protocol === 'https:')
+                      ) {
+                        return this.createError({
+                          message: 'Uri must be a url starting with http(s):// '
+                        });
+                      }
+                    }
+                  } else {
+                    if (url.protocol === 'javascript:') {
+                      return this.createError({
+                        message: "Uri can't be of schema 'javascript:'"
+                      });
+                    } else if (url.protocol === 'data:') {
+                      return this.createError({
+                        message: "Uri can't be of schema 'data:'"
+                      });
+                    }
+                  }
+                  if (value.includes('*')) {
+                    return this.createError({
+                      message: "Uri can't contain wildcard character '*'"
+                    });
+                  }
+                  if (value.includes(' ')) {
+                    return this.createError({
+                      message: "Uri can't contain spaces"
+                    });
+                  }
+                  return true;
+                }
+              })
+          )
+          .unique(t('yup_redirect_uri_unique'))
+          .when('grant_types', {
+            is: (grant_types) =>
+              grant_types?.includes('implicit') ||
+              grant_types?.includes('authorization_code'),
+            then: yup
+              .array()
+              .min(1, t('yup_required'))
+              .nullable()
+              .required(t('yup_required'))
+          })
+      }),
+    post_logout_redirect_uris: yup
+      .array()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .array()
+          .nullable()
+          .when('integration_environment', (integration_environment) => {
+            integrationEnvironment = integration_environment;
+          })
+          .when('application_type', (application_type_value) => {
+            application_type = application_type_value;
+          })
+          .of(
+            yup
+              .string()
+              .required("Uri can't be an empty string")
+              .test('test_redirect_uri', 'Invalid Post Logout Redirect Uri', function (
+                value
+              ) {
+                if (value) {
+                  let url;
+                  if (tenant?.config?.test_env.includes(integrationEnvironment)) {
+                    let isLocalIp =
+                      reg.regIpv4Local.test(value) || reg.regIpv6Local.test(value);
+                    if (isLocalIp) {
+                      return true;
+                    }
+                  }
+                  try {
+                    url = new URL(value);
+                  } catch (err) {
+                    return this.createError({ message: 'Invalid uri' });
+                  }
+                  if (value.includes('#')) {
+                    return this.createError({
+                      message: "Uri can't contain fragments"
+                    });
+                  }
+                  if (application_type === 'WEB') {
+                    if (!tenant?.config?.test_env.includes(integrationEnvironment)) {
+                      if (
+                        url.protocol !== 'https:' &&
+                        !(url.protocol === 'http:' && url.hostname === 'localhost')
+                      ) {
+                        return this.createError({
+                          message:
+                            'Uri must be a secure url starting with https://'
+                        });
+                      }
+                    } else {
+                      if (
+                        url &&
+                        !(url.protocol === 'http:' || url.protocol === 'https:')
+                      ) {
+                        return this.createError({
+                          message: 'Uri must be a url starting with http(s):// '
+                        });
+                      }
+                    }
+                  } else {
+                    if (url.protocol === 'javascript:') {
+                      return this.createError({
+                        message: "Uri can't be of schema 'javascript:'"
+                      });
+                    } else if (url.protocol === 'data:') {
+                      return this.createError({
+                        message: "Uri can't be of schema 'data:'"
+                      });
+                    }
+                  }
+                  if (value.includes('*')) {
+                    return this.createError({
+                      message: "Uri can't contain wildcard character '*'"
+                    });
+                  }
+                  if (value.includes(' ')) {
+                    return this.createError({
+                      message: "Uri can't contain spaces"
+                    });
+                  }
+                  return true;
+                }
+              })
+          )
+          .unique(t('yup_redirect_uri_unique'))
+      }),
+    logo_uri: yup
+      .string()
+      .nullable()
+      .matches(reg.regUrl, 'Logo must be be a secure url starting with https://')
+      .test('testImage', t('yup_image_url'), function (imageUrl) {
+        imageExists(imageUrl);
+        if (imageUrl && imageUrl.length > 6000) {
+          return this.createError({
+            message: 'Logo exceeds maximum character limit (6000)'
+          });
         }
-      })
-    }),
-    redirect_uris: yup.array().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.array().nullable().when('integration_environment', (integration_environment) => {
-        integrationEnvironment = integration_environment;
-      }).when('application_type', (application_type_value) => { application_type = application_type_value; }).of(yup.string().required("Uri can't be an empty string").test('test_redirect_uri', 'Invalid Redirect Uri', function (value) {
-        if (value) {
-          let url;
-          if (tenant?.config?.test_env.includes(integrationEnvironment)) {
-            let isLocalIp = reg.regIpv4Local.test(value) || reg.regIpv6Local.test(value);
-            if (isLocalIp) {
-              return true;
-            }
-          }
-          try {
-            url = new URL(value);
-          } catch (err) {
-            return this.createError({ message: "Invalid uri" });
-          }
-          if (value.includes('#')) {
-            return this.createError({ message: "Uri can't contain fragments" });
-          }
-          if (application_type === 'WEB') {
-            if (!tenant?.config?.test_env.includes(integrationEnvironment) && url) {
-              if (url.protocol !== 'https:' && !(url.protocol === 'http:' && url.hostname === 'localhost')) {
-                return this.createError({ message: "Uri must be a secure url starting with https://" });
-              }
-
-            }
-            else {
-              if (url && !(url.protocol === 'http:' || url.protocol === 'https:')) {
-                return this.createError({ message: "Uri must be a url starting with http(s):// " });
-              }
-            }
-          }
-          else {
-            // eslint-disable-next-line
-            if (url.protocol === "javascript:") {
-              return this.createError({ message: "Uri can't be of schema 'javascript:'" });
-            }
-            else if (url.protocol === 'data:') {
-              return this.createError({ message: "Uri can't be of schema 'data:'" });
-            }
-          }
-          if (value.includes('*')) {
-            return this.createError({ message: "Uri can't contain wildcard character '*'" });
-          }
-          if (value.includes(' ')) {
-            return this.createError({ message: "Uri can't contain spaces" });
-          }
-          return true
-        }
-      })).unique(t('yup_redirect_uri_unique')).when('grant_types', {
-        is: (grant_types) => grant_types?.includes("implicit") || grant_types?.includes("authorization_code"),
-        then: yup.array().min(1, t('yup_required')).nullable().required(t('yup_required'))
-      })
-    }),
-    post_logout_redirect_uris: yup.array().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.array().nullable().when('integration_environment', (integration_environment) => {
-        integrationEnvironment = integration_environment;
-      }).when('application_type', (application_type_value) => { application_type = application_type_value; }).of(yup.string().required("Uri can't be an empty string").test('test_redirect_uri', 'Invalid Post Logout Redirect Uri', function (value) {
-        if (value) {
-          let url
-          if (tenant?.config?.test_env.includes(integrationEnvironment)) {
-            let isLocalIp = reg.regIpv4Local.test(value) || reg.regIpv6Local.test(value);
-            if (isLocalIp) {
-              return true;
-            }
-          }
-          try {
-            url = new URL(value);
-          } catch (err) {
-            return this.createError({ message: "Invalid uri" });
-          }
-          if (value.includes('#')) {
-            return this.createError({ message: "Uri can't contain fragments" });
-          }
-          if (application_type === 'WEB') {
-            if (!tenant?.config?.test_env.includes(integrationEnvironment) && url) {
-              if (url.protocol !== 'https:' && !(url.protocol === 'http:' && url.hostname === 'localhost')) {
-                return this.createError({ message: "Uri must be a secure url starting with https://" });
-              }
-
-            }
-            else {
-              if (url && !(url.protocol === 'http:' || url.protocol === 'https:')) {
-                return this.createError({ message: "Uri must be a url starting with http(s):// " });
-              }
-            }
-          }
-          else {
-            // eslint-disable-next-line
-            if (url.protocol === "javascript:") {
-              return this.createError({ message: "Uri can't be of schema 'javascript:'" });
-            }
-            else if (url.protocol === 'data:') {
-              return this.createError({ message: "Uri can't be of schema 'data:'" });
-            }
-          }
-
-          if (value.includes('*')) {
-            return this.createError({ message: "Uri can't contain wildcard character '*'" });
-          }
-          if (value.includes(' ')) {
-            return this.createError({ message: "Uri can't contain spaces" });
-          }
-          return true
-        }
-      })).unique(t('yup_redirect_uri_unique'))
-    }),
-    logo_uri: yup.string().nullable().matches(reg.regUrl, 'Logo must be be a secure url starting with https://').test('testImage', t('yup_image_url'), function (imageUrl) {
-      imageExists(imageUrl);
-      if (imageUrl && imageUrl.length > 6000) {
-        return this.createError({ message: "Logo Url exceeds maximum character length (6000)" });
-      }
-      return true;
-    }),
-    country: yup.string().nullable().when('integration_environment', {
-      is: (integration_environment) => tenant?.form_config?.more_info?.country?.required.includes(integration_environment),
-      then: yup.string().test('testCountry', 'Select one of the available options', function (value) { return countries.includes(value) }).required(t('yup_required')),
-      otherwise: yup.string().nullable(),
-    }),
-    service_description: yup.string().nullable().required(t('yup_required')).max(1000, 'Exceeded maximum characters (1000)'),
-    requested_attributes: yup.array().nullable().of(yup.object().shape({
-      name: yup.string().nullable().required(t('yup_required')).min(1, t('yup_required')).required(t('yup_required')).max(512, 'Exceeded maximum characters (512)'),
-      friendly_name: yup.string().test('testAttributeName', 'invalid_name', function (friendly_name) {
-        return tenant.form_config.requested_attributes.some(e => e.friendly_name === friendly_name);
-      })
-    })),
-    contacts: yup.array().min(1, t('yup_required')).nullable().of(yup.object().shape({
-      email: yup.string().email(t('yup_email')).required(t('yup_contact_empty')),
-      type: yup.string().required(t('yup_required'))
-    })).test('testContacts', function (contacts) {
-      let errors = "";
-      tenant.form_config.contact_requirements.forEach((requirement, index) => {
-        let type_array = requirement.type.split(" ");
-        let requirement_met = false;
-        contacts.forEach(contact => {
-          if (type_array.includes(contact.type)) {
-            requirement_met = true;
-          }
-        })
-        if (!requirement_met) {
-          errors = (errors.length > 0 ? errors + ("\n") : errors) + requirement.error;
-        }
-      });
-      if (errors.length > 0) {
-        return this.createError({ message: errors });
-      }
-      else {
         return true;
-      }
-    }).test('testContacts', t('yup_contact_unique'), function (value) {
-      const array = [];
-      value.map(s => array.push(s.email + s.type));
-      const unique = array.filter((v, i, a) => a.indexOf(v) === i);
-      if (unique.length === array.length) { return true } else { return false }
-    }).required(t('yup_required')),
-    scope: yup.array().nullable().when(['protocol','grant_types'], {
-      is: (protocol,grant_types) => protocol === 'oidc' && grant_types?.length>0,
-      then: yup.array().min(1, t('yup_select_option')).nullable().of(yup.string().required("Scope value cannot be empty").min(1, t('yup_scope')).max(256, t('yup_char_max') + ' (' + 256 + ')').matches(reg.regScope, t('yup_scope_reg'))).unique(t('yup_scope_unique')).required(t('yup_required'))
-    }),
-    grant_types: yup.array().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.array().nullable().of(yup.string().test('testGrantTypes', 'error-grant-types', function (value) { return tenant.form_config.grant_types.includes(value) }))
-    }),
-    id_token_timeout_seconds: yup.number().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.number().nullable().min(1, "Must be a positive value greater that 0").max(tenant.form_config.id_token_timeout_seconds, t('yup_exceeds_max')).required('This is a required field')
-    }),
-    access_token_validation_model: yup.string().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.string()
-        .nullable()
-        .oneOf(['OFFLINE_VERIFIABLE', 'ONLINE_VALIDATION_REQUIRED'])
-        .required('This is a required field')
-    }),
-   access_token_validity_seconds: yup.number().nullable().when('protocol', {
-      is: 'oidc',
-
-      then: yup.number()
-        .nullable()
-        .min(
-          tenant.form_config.more_info?.access_token_validity_seconds?.min ?? 1,
-          t('yup_below_min')
-        )
-        .test(
-          'access-token-max-by-validation-model',
-          t('yup_exceeds_max'),
-          function (value) {
-            if (value === null || value === undefined || value === '') {
-              return true;
+      }),
+    country: yup
+      .string()
+      .nullable()
+      .when('integration_environment', {
+        is: (integration_environment) =>
+          tenant?.form_config?.more_info?.country?.required.includes(
+            integration_environment
+          ),
+        then: yup
+          .string()
+          .test('testCountry', 'Select one of the available options', function (
+            value
+          ) {
+            return countries.includes(value);
+          })
+          .required(t('yup_required')),
+        otherwise: yup.string().nullable()
+      }),
+    service_description: yup
+      .string()
+      .nullable()
+      .required(t('yup_required'))
+      .max(1000, 'Exceeded maximum characters (1000)'),
+    requested_attributes: yup
+      .array()
+      .nullable()
+      .of(
+        yup.object().shape({
+          name: yup
+            .string()
+            .nullable()
+            .required(t('yup_required'))
+            .min(1, t('yup_required'))
+            .max(512, 'Exceeded maximum characters (512)'),
+          friendly_name: yup
+            .string()
+            .test('testAttributeName', 'invalid_name', function (friendly_name) {
+              return tenant.form_config.requested_attributes.some(
+                (e) => e.friendly_name === friendly_name
+              );
+            })
+        })
+      ),
+    contacts: yup
+      .array()
+      .min(1, t('yup_required'))
+      .nullable()
+      .of(
+        yup.object().shape({
+          email: yup.string().email(t('yup_email')).required(t('yup_contact_empty')),
+          type: yup.string().required(t('yup_required'))
+        })
+      )
+      .test('testContacts', function (contacts) {
+        let errors = '';
+        if (!contacts) return true;
+        tenant.form_config.contact_requirements.forEach((requirement) => {
+          let type_array = requirement.type.split(' ');
+          let requirement_met = false;
+          contacts.forEach((contact) => {
+            if (type_array.includes(contact.type)) {
+              requirement_met = true;
             }
-
-            const validationModel =
-              this.parent.access_token_validation_model ||
-              'OFFLINE_VERIFIABLE';
-
-            const max =
-              tenant.form_config.more_info?.access_token_validity_seconds?.max?.[
-                validationModel
-              ] ??
-              tenant.form_config.more_info?.access_token_validity_seconds?.max
-                ?.OFFLINE_VERIFIABLE ??
-              tenant.form_config.access_token_validity_seconds ??
-              21600;
-
-            return Number(value) <= Number(max);
+          });
+          if (!requirement_met) {
+            errors =
+              errors.length > 0 ? errors + '\n' : errors;
+            errors += requirement.error;
           }
-        )
-        .required('This is a required field')
-    }),
-    refresh_token_validity_seconds: yup.number().nullable().when(
-      ['scope', 'protocol'],
-      {
+        });
+        if (errors.length > 0) {
+          return this.createError({ message: errors });
+        } else {
+          return true;
+        }
+      })
+      .test('testContacts', t('yup_contact_unique'), function (value) {
+        const array = [];
+        value.map((s) => array.push(s.email + s.type));
+        const unique = array.filter((v, i, a) => a.indexOf(v) === i);
+        if (unique.length === array.length) {
+          return true;
+        } else {
+          return false;
+        }
+      })
+      .required(t('yup_required')),
+    scope: yup
+      .array()
+      .nullable()
+      .when(['protocol', 'grant_types'], {
+        is: (protocol, grant_types) => protocol === 'oidc' && grant_types?.length > 0,
+        then: yup
+          .array()
+          .min(1, t('yup_select_option'))
+          .nullable()
+          .of(
+            yup
+              .string()
+              .required('Scope value cannot be empty')
+              .min(1, t('yup_scope'))
+              .max(256, t('yup_char_max') + ' (' + 256 + ')')
+              .matches(reg.regScope, t('yup_scope_reg'))
+          )
+          .unique(t('yup_scope_unique'))
+          .required(t('yup_required'))
+      }),
+    grant_types: yup
+      .array()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .array()
+          .nullable()
+          .of(
+            yup.string().test('testGrantTypes', 'error-grant-types', function (
+              value
+            ) {
+              return tenant.form_config.grant_types.includes(value);
+            })
+          )
+      }),
+    id_token_timeout_seconds: yup
+      .number()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .number()
+          .nullable()
+          .min(1, 'Must be a positive value greater that 0')
+          .max(tenant.form_config.id_token_timeout_seconds, t('yup_exceeds_max'))
+          .required('This is a required field')
+      }),
+    access_token_validation_model: yup
+      .string()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .string()
+          .nullable()
+          .oneOf(['OFFLINE_VERIFIABLE', 'ONLINE_VALIDATION_REQUIRED'])
+          .required('This is a required field')
+      }),
+    access_token_validity_seconds: yup
+      .number()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .number()
+          .nullable()
+          .min(
+            tenant.form_config.more_info?.access_token_validity_seconds?.min ?? 1,
+            t('yup_below_min')
+          )
+          .test(
+            'access-token-max-by-validation-model',
+            t('yup_exceeds_max'),
+            function (value) {
+              if (
+                value === null ||
+                value === undefined ||
+                value === ''
+              ) {
+                return true;
+              }
+
+              const validationModel =
+                this.parent.access_token_validation_model ||
+                'OFFLINE_VERIFIABLE';
+
+              const max =
+                tenant.form_config.more_info?.access_token_validity_seconds
+                  ?.max?.[validationModel] ??
+                tenant.form_config.more_info?.access_token_validity_seconds?.max
+                  ?.OFFLINE_VERIFIABLE ??
+                tenant.form_config.access_token_validity_seconds ??
+                21600;
+
+              return Number(value) <= Number(max);
+            }
+          )
+          .required('This is a required field')
+      }),
+    refresh_token_validity_seconds: yup
+      .number()
+      .nullable()
+      .when(['scope', 'protocol'], {
         is: (scope, protocol) =>
           protocol === 'oidc' && scope?.includes('offline_access'),
-
-        then: yup.number()
+        then: yup
+          .number()
           .nullable()
           .min(
             tenant.form_config.more_info?.refresh_token_validity_seconds?.min ?? 1,
@@ -549,274 +805,445 @@ const ServiceForm = (props) => {
           )
           .max(
             tenant.form_config.more_info?.refresh_token_validity_seconds?.max ??
-            tenant.form_config.refresh_token_validity_seconds ??
-            34560000,
+              tenant.form_config.refresh_token_validity_seconds ??
+              34560000,
             t('yup_exceeds_max')
           )
           .required(
             'This field is required when the offline_access is selected'
           )
-      }
-    ),
-    device_code_validity_seconds: yup.number().nullable().when(['protocol', 'grant_types'], {
-      is: (protocol, grant_types) => protocol === 'oidc' && grant_types?.includes('urn:ietf:params:oauth:grant-type:device_code'),
-      then: yup.number().nullable().min(0).max(tenant.form_config.device_code_validity_seconds, t('yup_exceeds_max')).required('This is a required field when the device code grant type is selected')
-    }),
-    code_challenge_method: yup.string().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.string().nullable().test('test_code_challenge_method', 'Invalid Value', function (value) {
-        if (!value) {
-          return true;
-        }
-        else {
-          return tenant.form_config.code_challenge_method.includes(value)
-        }
-      })
-    }).when(['token_endpoint_auth_method', 'grant_types'], {
-      is: (token_endpoint_auth_method, grant_types) => token_endpoint_auth_method === 'none' && grant_types.includes('authorization_code'),
-      then: yup.string().nullable().test('extra_validation', "PKCE must be enabled when no authentication is selected for the authorization code grant type.", function (value) { return value })
-    }),
-    allow_introspection: yup.boolean().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.boolean().required()
-    }),
-    generate_client_secret: yup.boolean().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.boolean().required()
-    }),
-    reuse_refresh_token: yup.boolean().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.boolean().nullable().required()
-    }),
-    protocol: yup.string().test('testProtocol', t('yup_protocol'), function (value) { return ['saml', 'oidc'].includes(value) }).required(t('yup_protocol')),
-    integration_environment: yup.string().test('testIntegrationEnv', 'Invalid Value', function (value) { return tenant.form_config.integration_environment.includes(value) }).required(t('yup_select_option')),
-    clear_access_tokens_on_refresh: yup.boolean().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.boolean().nullable().required()
-    }),
-    client_secret: yup.string().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.string().nullable().when(['generate_client_secret', 'token_endpoint_auth_method'], {
-        is: (generate_client_secret, token_endpoint_auth_method) => generate_client_secret === false && !(token_endpoint_auth_method === 'private_key_jwt' || token_endpoint_auth_method === 'none'),
-        then: yup.string().nullable().required(t('yup_required')).min(4, t('yup_char_min') + ' (' + 4 + ')').max(256, t('yup_char_max') + ' (' + 256 + ')')
-      }).nullable()
-    }),
-    metadata_url: yup.string().nullable().when('protocol', {
-      is: 'saml',
-      then: yup.string().nullable().required(t('yup_required')).matches(reg.regSimpleUrl, 'Enter a valid Url').test('testXml', 'Invalid Metadata', function (value) {
-        // Metadata Url is Already Loaded?
-
-        // if(!value||metadataChecked!==value){
-        //   setMetadataLoading(false);
-        //   //setMetadataWarning();
-        //   clearTimeout(metadataUrlLoadTimeout);
-        // }        
-        // if(value&&value.match(reg.regSimpleUrl)&&metadataChecked!==value&&value!==metadataLoaded.metadata_url){
-        //   new Promise((resolve,reject)=>{
-        //     getMetadata(value,resolve);
-        //   })
-        // }
-
-
-
-        if (value && value.match(reg.regSimpleUrl) && metadataChecked !== value && value !== metadataLoaded.metadata_url) {
-          clearTimeout(timeouts[timeoutId]);
-          new Promise((resolve, reject) => {
-            getMetadata(value, resolve);
-          })
-        }
-        else {
-          setMetadataLoading(false);
-        }
-        if (metadataAsyncError) {
-          return this.createError({ message: metadataAsyncError })
-        }
-        return true
-
-
-
-
-      })
-
-    }),
-    token_endpoint_auth_signing_alg: yup.string().nullable().when(['protocol', "token_endpoint_auth_method"], {
-      is: (protocol, token_endpoint_auth_method) => protocol === 'oidc' && (token_endpoint_auth_method === "private_key_jwt" || token_endpoint_auth_method === "client_secret_jwt"),
-      then: yup.string().required(t('yup_select_option')).test('testTokenEndpointSigningAlgorithm', 'Invalid Value', function (value) { return tenant.form_config.token_endpoint_auth_signing_alg.includes(value) })
-    }),
-    application_type: yup.string().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.string().nullable().required(t('yup_select_option')).test('testApplicationType', 'Invalid Value', function (value) { return tenant.form_config.application_type.includes(value) })
-    }),
-    token_endpoint_auth_method: yup.string().nullable().when('protocol', {
-      is: 'oidc',
-      then: yup.string().nullable().required(t('yup_select_option')).test('testTokenEndpointAuthMethod', 'Invalid Value', function (value) { return tenant.form_config.token_endpoint_auth_method.includes(value) })
-    }),
-    jwks_uri: yup.string().nullable().when(['protocol', 'token_endpoint_auth_method'], {
-      is: (protocol, token_endpoint_auth_method) => protocol === 'oidc' && token_endpoint_auth_method === "private_key_jwt",
-      then: yup.string().nullable().test('test', 'Required Field', function (value) { if (this.parent.jwks || value) { return true } else { return false } }).test('testTokenEndpointAuthMethod', 'Invalid Value', function (value) { if (this.parent.jwks || (value && reg.regSimpleUrl.test(value))) { return true } else { return false } })
-    }),
-    jwks: yup.object().typeError("test").nullable().when(['protocol', 'jwks_uri', 'token_endpoint_auth_method'], {
-      is: (protocol, jwks_uri, token_endpoint_auth_method) => protocol === 'oidc' && !jwks_uri && token_endpoint_auth_method === "private_key_jwt",
-      then: yup.object().nullable().test('test', 'Required Field', function (value) { if (this.parent.jwks_uri || value) { return true } else { return false } }).test('testJwks', 'Invalid Schema', function (value) {
-        if (!value) {
-          return true
-        }
-        else if (value.keys && typeof (value.keys) === 'object' && Object.keys(value).length === 1) {
-          return true
-        }
-        else {
-          return false
-        }
-      })
-    }),
-    organization_name: yup.string().nullable().when(['integration_environment'], {
-      is: (integration_environment) => tenant.form_config.extra_fields.organization.required.includes(integration_environment),
-      then: yup.string().nullable().required('This is a required field')
-    }),
-    organization_url: yup.string().nullable().nullable().when(['integration_environment'], {
-      is: (integration_environment) => tenant.form_config.extra_fields.organization.required.includes(integration_environment),
-      then: yup.string().nullable().matches(reg.regSimpleUrl, t('yup_secure_url')).required('This is a required field')
-    }),
-    entity_id: yup.string().matches(reg.regUrl, t('yup_secure_url')).nullable().when('protocol', {
-      is: 'saml',
-      then: yup.string().nullable().required('This is a required field').min(4, t('yup_char_min') + ' (' + 4 + ')').test('testAvailable', t('yup_entity_id'), function (value) {
-        if (props.initialValues.entity_id === value && !props.copy) {
-          return true
-        }
-        else {
-          return new Promise((resolve, reject) => {
-
-            clearTimeout(availabilityCheckTimeout);
-            if (!value || !reg.regUrl.test(value)) { resolve(true) }
-            else {
-              setCheckingAvailability(true);
-              //&&!(props.copy&&)
-              if (value === checkedId && formRef.current.values.integration_environment === checkedEnvironment) {
-                setCheckingAvailability(false);
-                resolve(availabilityCheck);
-              }
-              else {
-                availabilityCheckTimeout = setTimeout(() => {
-                  fetch(config.host[tenant_name] + 'tenants/' + tenant_name + '/check-availability?value=' + value + '&protocol=saml&environment=' + this.parent.integration_environment + (petition_id ? ('&petition_id=' + petition_id) : "") + (service_id ? ('&service_id=' + service_id) : ""), {
-                    method: 'GET',
-                    credentials: 'include',
-                    headers: {
-                      'Content-Type': 'application/json'
-                    }
-                  }).then(response => {
-                    if (response.status === 200) {
-
-                      return response.json();
-                    }
-                    else {
-                      return false
-                    }
-                  }).then(response => {
-                    setCheckedId(value);
-                    setCheckedEnvironment(this.parent.integration_environment);
-                    setCheckingAvailability(false);
-                    if (response) {
-                      setCheckedId(value);
-                      setAvailabilityCheck(response.available);
-                      resolve(response.available)
-                    }
-                    else {
-                      resolve(false);
-                    }
-                  }
-                  ).catch(() => { resolve(true) })
-                }, 1000);
-              }
-
+      }),
+    device_code_validity_seconds: yup
+      .number()
+      .nullable()
+      .when(['protocol', 'grant_types'], {
+        is: (protocol, grant_types) =>
+          protocol === 'oidc' &&
+          grant_types?.includes('urn:ietf:params:oauth:grant-type:device_code'),
+        then: yup
+          .number()
+          .nullable()
+          .min(0)
+          .max(tenant.form_config.device_code_validity_seconds, t('yup_exceeds_max'))
+          .required(
+            'This is a required field when the device code grant type is selected'
+          )
+      }),
+    code_challenge_method: yup
+      .string()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .string()
+          .nullable()
+          .test('test_code_challenge_method', 'Invalid Value', function (value) {
+            if (!value) {
+              return true;
+            } else {
+              return tenant.form_config.code_challenge_method.includes(value);
             }
           })
-
-        }
       })
-    })
+      .when(['token_endpoint_auth_method', 'grant_types'], {
+        is: (token_endpoint_auth_method, grant_types) =>
+          token_endpoint_auth_method === 'none' &&
+          grant_types.includes('authorization_code'),
+        then: yup
+          .string()
+          .nullable()
+          .test(
+            'extra_validation',
+            'PKCE must be enabled when no authentication is selected for the authorization code grant type.',
+            function (value) {
+              return value;
+            }
+          )
+      }),
+    allow_introspection: yup
+      .boolean()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup.boolean().required()
+      }),
+    generate_client_secret: yup
+      .boolean()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup.boolean().required()
+      }),
+    reuse_refresh_token: yup
+      .boolean()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup.boolean().nullable().required()
+      }),
+    protocol: yup
+      .string()
+      .test('testProtocol', t('yup_protocol'), function (value) {
+        return ['saml', 'oidc'].includes(value);
+      })
+      .required(t('yup_protocol')),
+    integration_environment: yup
+      .string()
+      .test('testIntegrationEnv', 'Invalid Value', function (value) {
+        return tenant.form_config.integration_environment.includes(value);
+      })
+      .required(t('yup_select_option')),
+    clear_access_tokens_on_refresh: yup
+      .boolean()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup.boolean().nullable().required()
+      }),
+    client_secret: yup
+      .string()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .string()
+          .nullable()
+          .when(['generate_client_secret', 'token_endpoint_auth_method'], {
+            is: (generate_client_secret, token_endpoint_auth_method) =>
+              generate_client_secret === false &&
+              !(
+                token_endpoint_auth_method === 'private_key_jwt' ||
+                token_endpoint_auth_method === 'none'
+              ),
+            then: yup
+              .string()
+              .nullable()
+              .required(t('yup_required'))
+              .min(4, t('yup_char_min') + ' (' + 4 + ')')
+              .max(256, t('yup_char_max') + ' (' + 256 + ')')
+          })
+          .nullable()
+      }),
+    metadata_url: yup
+      .string()
+      .nullable()
+      .when('protocol', {
+        is: 'saml',
+        then: yup
+          .string()
+          .nullable()
+          .required(t('yup_required'))
+          .matches(reg.regSimpleUrl, 'Enter a valid Url')
+          .test('testXml', 'Invalid Metadata', function (value) {
+            if (
+              value &&
+              value.match(reg.regSimpleUrl) &&
+              metadataChecked !== value &&
+              value !== metadataLoaded.metadata_url
+            ) {
+              clearTimeout(timeouts[timeoutId]);
+              new Promise((resolve, reject) => {
+                getMetadata(value, resolve);
+              });
+            } else {
+              setMetadataLoading(false);
+            }
+            if (metadataAsyncError) {
+              return this.createError({ message: metadataAsyncError });
+            }
+            return true;
+          })
+      }),
+    token_endpoint_auth_signing_alg: yup
+      .string()
+      .nullable()
+      .when(['protocol', 'token_endpoint_auth_method'], {
+        is: (protocol, token_endpoint_auth_method) =>
+          protocol === 'oidc' &&
+          (token_endpoint_auth_method === 'private_key_jwt' ||
+            token_endpoint_auth_method === 'client_secret_jwt'),
+        then: yup
+          .string()
+          .required(t('yup_select_option'))
+          .test(
+            'testTokenEndpointSigningAlgorithm',
+            'Invalid Value',
+            function (value) {
+              return tenant.form_config.token_endpoint_auth_signing_alg.includes(
+                value
+              );
+            }
+          )
+      }),
+    application_type: yup
+      .string()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .string()
+          .nullable()
+          .required(t('yup_select_option'))
+          .test('testApplicationType', 'Invalid Value', function (value) {
+            return tenant.form_config.application_type.includes(value);
+          })
+      }),
+    token_endpoint_auth_method: yup
+      .string()
+      .nullable()
+      .when('protocol', {
+        is: 'oidc',
+        then: yup
+          .string()
+          .nullable()
+          .required(t('yup_select_option'))
+          .test('testTokenEndpointAuthMethod', 'Invalid Value', function (value) {
+            return tenant.form_config.token_endpoint_auth_method.includes(value);
+          })
+      }),
+    jwks_uri: yup
+      .string()
+      .nullable()
+      .when(['protocol', 'token_endpoint_auth_method'], {
+        is: (protocol, token_endpoint_auth_method) =>
+          protocol === 'oidc' &&
+          token_endpoint_auth_method === 'private_key_jwt',
+        then: yup
+          .string()
+          .nullable()
+          .test('test', 'Required Field', function (value) {
+            if (this.parent.jwks || value) {
+              return true;
+            } else {
+              return false;
+            }
+          })
+          .test('testTokenEndpointAuthMethod', 'Invalid Value', function (value) {
+            if (
+              this.parent.jwks ||
+              (value && reg.regSimpleUrl.test(value))
+            ) {
+              return true;
+            } else {
+              return false;
+            }
+          })
+      }),
+    jwks: yup
+      .object()
+      .typeError('test')
+      .nullable()
+      .when(['protocol', 'jwks_uri', 'token_endpoint_auth_method'], {
+        is: (protocol, jwks_uri, token_endpoint_auth_method) =>
+          protocol === 'oidc' &&
+          !jwks_uri &&
+          token_endpoint_auth_method === 'private_key_jwt',
+        then: yup
+          .object()
+          .nullable()
+          .test('test', 'Required Field', function (value) {
+            if (this.parent.jwks_uri || value) {
+              return true;
+            } else {
+              return false;
+            }
+          })
+          .test('testJwks', 'Invalid Schema', function (value) {
+            if (!value) {
+              return true;
+            } else if (
+              value.keys &&
+              typeof value.keys === 'object' &&
+              Object.keys(value).length === 1
+            ) {
+              return true;
+            } else {
+              return false;
+            }
+          })
+      }),
+    organization_name: yup
+      .string()
+      .nullable()
+      .when(['integration_environment'], {
+        is: (integration_environment) =>
+          tenant.form_config.extra_fields.organization.required.includes(
+            integration_environment
+          ),
+        then: yup.string().nullable().required('This is a required field')
+      }),
+    organization_url: yup
+      .string()
+      .nullable()
+      .nullable()
+      .when(['integration_environment'], {
+        is: (integration_environment) =>
+          tenant.form_config.extra_fields.organization.required.includes(
+            integration_environment
+          ),
+        then: yup
+          .string()
+          .nullable()
+          .matches(reg.regSimpleUrl, t('yup_secure_url'))
+          .required('This is a required field')
+      }),
+    entity_id: yup
+      .string()
+      .matches(reg.regUrl, t('yup_secure_url'))
+      .nullable()
+      .when('protocol', {
+        is: 'saml',
+        then: yup
+          .string()
+          .nullable()
+          .required('This is a required field')
+          .min(4, t('yup_char_min') + ' (' + 4 + ')')
+          .test('testAvailable', t('yup_entity_id'), function (value) {
+            if (props.initialValues.entity_id === value && !props.copy) {
+              return true;
+            } else {
+              return new Promise((resolve, reject) => {
+                clearTimeout(availabilityCheckTimeout);
+                if (!value || !reg.regUrl.test(value)) {
+                  resolve(true);
+                } else {
+                  setCheckingAvailability(true);
+                  if (
+                    value === checkedId &&
+                    formRef.current.values.integration_environment ===
+                      checkedEnvironment
+                  ) {
+                    setCheckingAvailability(false);
+                    resolve(availabilityCheck);
+                  } else {
+                    availabilityCheckTimeout = setTimeout(() => {
+                      fetch(
+                        config.host[tenant_name] +
+                          'tenants/' +
+                          tenant_name +
+                          '/check-availability?value=' +
+                          value +
+                          '&protocol=saml&environment=' +
+                          this.parent.integration_environment +
+                          (petition_id ? '&petition_id=' + petition_id : '') +
+                          (service_id ? '&service_id=' + service_id : ''),
+                        {
+                          method: 'GET',
+                          credentials: 'include',
+                          headers: {
+                            'Content-Type': 'application/json'
+                          }
+                        }
+                      )
+                        .then((response) => {
+                          if (response.status === 200) {
+                            return response.json();
+                          } else {
+                            return false;
+                          }
+                        })
+                        .then((response) => {
+                          setCheckedId(value);
+                          setCheckedEnvironment(
+                            this.parent.integration_environment
+                          );
+                          setCheckingAvailability(false);
+                          if (response) {
+                            setCheckedId(value);
+                            setAvailabilityCheck(response.available);
+                            resolve(response.available);
+                          } else {
+                            resolve(false);
+                          }
+                        })
+                        .catch(() => {
+                          resolve(true);
+                        });
+                    }, 1000);
+                  }
+                }
+              });
+            }
+          })
+      })
   });
-
-
 
   const toggleCopyDialog = () => {
     setShowCopyDialog(!showCopyDialog);
-  }
+  };
 
   const toggleMoveDialog = () => {
     setShowMoveDialog(!showMoveDialog);
-  }
+  };
 
   const canReview = (integration_environment) => {
     return (
-      // Allow when user can review service requests targeting a restricted ennvironment    
-      (props.user.actions.includes('review_restricted') && tenant?.config?.restricted_env.includes(integration_environment))
-      ||
-      // Allow when user can review their own petition and service request targets a testing environment
-      (tenant?.config?.test_env.includes(integration_environment) && props.user.actions.includes('review_own_petition'))
-      ||
-      // Allow when user can review all petitions and service request does not target a restricted environment 
-      (props.user.actions.includes('review_petition') && !tenant?.config?.restricted_env.includes(integration_environment))
+      (props.user.actions.includes('review_restricted') &&
+        tenant?.config?.restricted_env.includes(integration_environment)) ||
+      (tenant?.config?.test_env.includes(integration_environment) &&
+        props.user.actions.includes('review_own_petition')) ||
+      (props.user.actions.includes('review_petition') &&
+        !tenant?.config?.restricted_env.includes(integration_environment))
     );
-  }
+  };
 
   const createNewPetition = (petition) => {
-    // eslint-disable-next-line
     if (service_id) {
       petition.type = 'edit';
-
       petition.service_id = service_id;
-    }
-    else {
+    } else {
       petition.type = 'create';
       petition.service_id = null;
     }
     if (diff(petition, props.initialValues) || props.copy) {
       setAsyncResponse(true);
       fetch(config.host[tenant_name] + 'tenants/' + tenant_name + '/petitions', {
-        method: 'POST', // *GET, POST, PUT, DELETE, etc.
-        credentials: 'include', // include, *same-origin, omit
+        method: 'POST',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify(petition)
-      }).then(async response => {
-        setAsyncResponse(false);
-        let responseData = await response.json();
-        if (response.status === 200) {
-          let reviewEnabled = canReview(petition.integration_environment);
-          setModalData({
-            title: t('new_petition_title'),
-            message: reviewEnabled ? t('petition_success_review_msg') : t('petition_success_msg'),
-            service_id: service_id,
-            tenant: tenant_name,
-            petition_id: responseData.id,
-            reviewEnabled
-          });
-        }
-        else if (response.status === 401) {
-          setLogout(true);
-        }
-        else {
-          setModalData({
-            title: t('new_petition_title'),
-            message: t('petition_error_msg') + response.status,
-            tenant: tenant_name,
-            reviewEnabled: false
-          })
-        }
-      });
-    }
-    else {
+      })
+        .then(async (response) => {
+          setAsyncResponse(false);
+          let responseData = await response.json();
+          if (response.status === 200) {
+            let reviewEnabled = canReview(petition.integration_environment);
+            setModalData({
+              title: t('new_petition_title'),
+              message: reviewEnabled
+                ? t('petition_success_review_msg')
+                : t('petition_success_msg'),
+              service_id: service_id,
+              tenant: tenant_name,
+              petition_id: responseData.id,
+              reviewEnabled
+            });
+          } else if (response.status === 401) {
+            setLogout(true);
+          } else {
+            setModalData({
+              title: t('new_petition_title'),
+              message: t('petition_error_msg') + response.status,
+              tenant: tenant_name,
+              reviewEnabled: false
+            });
+          }
+        })
+        .catch(() => {
+          setAsyncResponse(false);
+        });
+    } else {
       setAsyncResponse(false);
       setModalData({
         title: t('petition_no_change_title'),
         message: t('petition_no_change_msg'),
         tenant: tenant_name,
         reviewEnabled: false
-      })
+      });
     }
-  }
-
+  };
 
   const editPetition = (petition) => {
     petition.type = props.type;
@@ -826,44 +1253,52 @@ const ServiceForm = (props) => {
     }
     if (diff(petition, props.initialValues)) {
       setAsyncResponse(true);
-      fetch(config.host[tenant_name] + 'tenants/' + tenant_name + '/petitions/' + petition_id, {
-        method: 'PUT', // *GET, POST, PUT, DELETE, etc.
-        credentials: 'include', // include, *same-origin, omit
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(petition) // body data type must match "Content-Type" header
-      }).then(async response => {
-
-        setAsyncResponse(false);
-        let reviewEnabled = canReview(petition.integration_environment);
-        if (response.status === 200) {
-          setModalData({
-            title: t('edit_petition_title'),
-            message: reviewEnabled ? t('petition_success_review_msg') : t('petition_success_msg'),
-            service_id: service_id,
-            tenant: tenant_name,
-            petition_id: petition_id,
-            reviewEnabled
-          });
+      fetch(
+        config.host[tenant_name] +
+          'tenants/' +
+          tenant_name +
+          '/petitions/' +
+          petition_id,
+        {
+          method: 'PUT',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(petition)
         }
-        else if (response.status === 401) {
-          setLogout(true);
-        }
-        else if (response.status === 404) {
-          setNotFound(true);
-        }
-        else {
-          setModalData({
-            title: t('new_petition_title'),
-            message: t('petition_error_msg') + response.status,
-            tenant: tenant_name,
-            reviewEnabled: false
-          })
-        }
-      });
-    }
-    else {
+      )
+        .then(async (response) => {
+          setAsyncResponse(false);
+          let reviewEnabled = canReview(petition.integration_environment);
+          if (response.status === 200) {
+            setModalData({
+              title: t('edit_petition_title'),
+              message: reviewEnabled
+                ? t('petition_success_review_msg')
+                : t('petition_success_msg'),
+              service_id: service_id,
+              tenant: tenant_name,
+              petition_id: petition_id,
+              reviewEnabled
+            });
+          } else if (response.status === 401) {
+            setLogout(true);
+          } else if (response.status === 404) {
+            setNotFound(true);
+          } else {
+            setModalData({
+              title: t('new_petition_title'),
+              message: t('petition_error_msg') + response.status,
+              tenant: tenant_name,
+              reviewEnabled: false
+            });
+          }
+        })
+        .catch(() => {
+          setAsyncResponse(false);
+        });
+    } else {
       setModalData({
         title: t('petition_no_change_title'),
         message: t('petition_no_change_msg'),
@@ -871,77 +1306,81 @@ const ServiceForm = (props) => {
         reviewEnabled: false
       });
     }
-  }
+  };
 
   const deletePetition = () => {
     setAsyncResponse(true);
     fetch(config.host[tenant_name] + 'tenants/' + tenant_name + '/petitions/' + petition_id, {
-      method: 'DELETE', // *GET, POST, PUT, DELETE, etc.
-      credentials: 'include', // include, *same-origin, omit
+      method: 'DELETE',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json'
       }
-    }).then(response => {
-      setAsyncResponse(false);
-      if (response.status === 200) {
-        setModalData({
-          title: t('request_submit_title'),
-          message: t('request_cancel_success_msg'),
-          tenant: tenant_name,
-          reviewEnabled: false
-        });
-      }
-      else if (response.status === 401) {
-        setLogout(true);
-      }
-      else if (response.status === 404) {
-        setNotFound(true);
-      }
-      else {
-        setModalData({
-          title: t('request_submit_title'),
-          message: t('request_cancel_fail_msg') + response.status,
-          tenant: tenant_name,
-          reviewEnabled: false
-        });
-      }
-    });
-  }
+    })
+      .then((response) => {
+        setAsyncResponse(false);
+        if (response.status === 200) {
+          setModalData({
+            title: t('request_submit_title'),
+            message: t('request_cancel_success_msg'),
+            tenant: tenant_name,
+            reviewEnabled: false
+          });
+        } else if (response.status === 401) {
+          setLogout(true);
+        } else if (response.status === 404) {
+          setNotFound(true);
+        } else {
+          setModalData({
+            title: t('request_submit_title'),
+            message: t('request_cancel_fail_msg') + response.status,
+            tenant: tenant_name,
+            reviewEnabled: false
+          });
+        }
+      })
+      .catch(() => {
+        setAsyncResponse(false);
+      });
+  };
 
   const addOrganization = async (data) => {
     if (!data.organization_id) {
-      return await fetch(config.host[tenant_name] + 'tenants/' + tenant_name + '/organizations', {
-        method: 'POST', // *GET, POST, PUT, DELETE, etc.
-        credentials: 'include', // include, *same-origin, omit
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ organization_name: data.organization_name, organization_url: data.organization_url, ror_id: data.ror_id })
-      }).then(response => {
-        if (response.status === 200 || response.status === 409) {
-          return response.json();
+      return await fetch(
+        config.host[tenant_name] + 'tenants/' + tenant_name + '/organizations',
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            organization_name: data.organization_name,
+            organization_url: data.organization_url,
+            ror_id: data.ror_id
+          })
         }
-        else if (response.status === 401) {
-          setLogout(true);
-        }
-        else {
-          return false
-        }
-      }).then((response) => {
-        if (response) {
-          return response.organization_id;
-        }
-        else {
-          return response
-        }
-
-      })
-    }
-    else {
+      )
+        .then((response) => {
+          if (response.status === 200 || response.status === 409) {
+            return response.json();
+          } else if (response.status === 401) {
+            setLogout(true);
+          } else {
+            return false;
+          }
+        })
+        .then((response) => {
+          if (response) {
+            return response.organization_id;
+          } else {
+            return response;
+          }
+        });
+    } else {
       return data.organization_id;
     }
-
-  }
+  };
 
   const getTags = () => {
     fetch(config.host[tenant_name] + 'tenants/' + tenant_name + '/tags/services/' + service_id, {
@@ -950,96 +1389,104 @@ const ServiceForm = (props) => {
       headers: {
         'Content-Type': 'application/json'
       }
-    }).then(response => {
-      if (response.status === 200) {
-        return response.json();
-      }
-      else if (response.status === 401) {
-        setLogout(true);
-      }
-      else {
-        return false
-      }
-    }).then((response) => {
-      if (response) {
-        setServiceTags(response);
-      }
-      else {
-        setServiceTags([]);
-      }
     })
-  }
-
+      .then((response) => {
+        if (response.status === 200) {
+          return response.json();
+        } else if (response.status === 401) {
+          setLogout(true);
+        } else {
+          return false;
+        }
+      })
+      .then((response) => {
+        if (response) {
+          setServiceTags(response);
+        } else {
+          setServiceTags([]);
+        }
+      });
+  };
 
   const reviewPetition = (comment, type) => {
     setAsyncResponse(true);
-    fetch(config.host[tenant_name] + 'tenants/' + tenant_name + '/petitions/' + petition_id + '/review', {
-      method: 'PUT', // *GET, POST, PUT, DELETE, etc.
-      credentials: 'include', // include, *same-origin, omit
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ comment: comment, type: type })
-    }).then(response => {
-      setAsyncResponse(false);
-      if (response.status === 200) {
-        setModalData({
-          title: t('review_' + props.type + '_title'),
-          tenant: tenant_name,
-          message: t('review_success'),
-          reviewEnabled: false
-        });
+    fetch(
+      config.host[tenant_name] +
+        'tenants/' +
+        tenant_name +
+        '/petitions/' +
+        petition_id +
+        '/review',
+      {
+        method: 'PUT',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ comment: comment, type: type })
       }
-      else if (response.status === 401) {
-        setLogout(true);
-        return false;
-      }
-      else if (response.status === 404) {
-        setNotFound(true);
-        return false;
-      }
-      else {
-        setModalData({
-          title: t('review_' + props.type + '_title'),
-          message: t('review_error') + response.status,
-          tenant: tenant_name,
-          reviewEnabled: false
-        });
-      }
-    });
-  }
-
-
+    )
+      .then((response) => {
+        setAsyncResponse(false);
+        if (response.status === 200) {
+          setModalData({
+            title: t('review_' + props.type + '_title'),
+            tenant: tenant_name,
+            message: t('review_success'),
+            reviewEnabled: false
+          });
+        } else if (response.status === 401) {
+          setLogout(true);
+          return false;
+        } else if (response.status === 404) {
+          setNotFound(true);
+          return false;
+        } else {
+          setModalData({
+            title: t('review_' + props.type + '_title'),
+            message: t('review_error') + response.status,
+            tenant: tenant_name,
+            reviewEnabled: false
+          });
+        }
+      })
+      .catch(() => {
+        setAsyncResponse(false);
+      });
+  };
 
   const postApi = async (data) => {
     data = generateValues(data);
     let organization_id;
     let createOrganization;
-    if (!tenant.form_config.extra_fields.organization.hide.includes(data.integration_environment)&& data.organization_name && data.organization_url             ) {
+    if (
+      !tenant.form_config.extra_fields.organization.hide.includes(
+        data.integration_environment
+      ) &&
+      data.organization_name &&
+      data.organization_url
+    ) {
       createOrganization = true;
       organization_id = await addOrganization(data);
-      data.organization_id = organization_id;      
+      data.organization_id = organization_id;
     }
     if (organization_id || !createOrganization) {
       if (!props.type) {
         createNewPetition(data);
-      }
-      else {
+      } else {
         data.type = props.type;
         editPetition(data);
       }
+    } else {
+      setNotFound(true);
     }
-    else {
-      setNotFound(true)
-    }
-  }
+  };
 
   const getInitialTouched = (initVal) => {
     let touchedActive = {};
     if (!(service_id || petition_id)) {
-      return {}
-    }
-    else {
+      return {};
+    } else {
       for (const property in initVal) {
         touchedActive[property] = true;
       }
@@ -1048,25 +1495,55 @@ const ServiceForm = (props) => {
           touchedActive[property] = true;
         }
       }
-
       return touchedActive;
     }
-  }
+  };
+
   const protocolOptions = (protocols) => {
     let options = [];
-    protocols.forEach(protocol => {
+    protocols.forEach((protocol) => {
       options.push(protocol.toUpperCase() + ' Service');
-    })
-    return options
-  }
+    });
+    return options;
+  };
 
+  const generateValues = (values) => {
+    let result = { ...values };
+    if (result.metadata_url && result.metadata_url !== '') {
+      result.metadataUrl = result.metadata_url;
+    }
+    if (result.website_url && result.website_url !== '') {
+      result.website = result.website_url;
+    }
+    if (result.policy_uri && result.policy_uri !== '') {
+      result.policyUri = result.policy_uri;
+    }
+    if (result.organization_url && result.organization_url !== '') {
+      result.organizationUrl = result.organization_url;
+    }
+    if (result.entity_id && result.entity_id !== '') {
+      result.entityID = result.entity_id;
+    }
+    if (result.logo_uri && result.logo_uri !== '') {
+      result.logoURI = result.logo_uri;
+    }
+    return result;
+  };
 
   return (
     <React.Fragment>
       <Logout logout={logout} />
-      <ManageTags manageTags={manageTags} setManageTags={setManageTags} tags={serviceTags} service_id={service_id} getServices={() => { getTags() }} />
+      <ManageTags
+        manageTags={manageTags}
+        setManageTags={setManageTags}
+        tags={serviceTags}
+        service_id={service_id}
+        getServices={() => {
+          getTags();
+        }}
+      />
       <NotFound notFound={notFound} />
-      {formValues ?
+      {formValues ? (
         <Formik
           initialValues={formValues}
           validateOnMount={service_id || petition_id || props.copy}
@@ -1076,18 +1553,25 @@ const ServiceForm = (props) => {
           innerRef={formRef}
           validate={dynamicValidation}
           onSubmit={(values, { setSubmitting }) => {
-
             setSubmitting(true);
             setHasSubmitted(true);
             setSubmitDisabled(true);
-            if (!(values.token_endpoint_auth_method === "client_secret_jwt" || values.token_endpoint_auth_method === "private_key_jwt")) {
+            if (
+              !(
+                values.token_endpoint_auth_method === 'client_secret_jwt' ||
+                values.token_endpoint_auth_method === 'private_key_jwt'
+              )
+            ) {
               values.token_endpoint_auth_signing_alg = null;
             }
-            if (values.token_endpoint_auth_method !== "private_key_jwt") {
+            if (values.token_endpoint_auth_method !== 'private_key_jwt') {
               values.jwks = null;
               values.jwks_uri = null;
             }
-            if (values.token_endpoint_auth_method === "private_key_jwt" || values.token_endpoint_auth_method === "none") {
+            if (
+              values.token_endpoint_auth_method === 'private_key_jwt' ||
+              values.token_endpoint_auth_method === 'none'
+            ) {
               values.client_secret = '';
             }
             if (values.jwks_uri) {
@@ -1096,11 +1580,8 @@ const ServiceForm = (props) => {
             if (values.jwks) {
               values.jwks = JSON.parse(values.jwks);
               values.jwks_uri = null;
-              // let check = values.jwks.replace(/\n/g, "\\\\n").replace(/\r/g, "\\\\r").replace(/\t/g, "\\\\t");
-              // values.jwks = JSON.parse(check);
             }
             postApi(values);
-
           }}
         >
           {({
@@ -1119,873 +1600,320 @@ const ServiceForm = (props) => {
             setErrors,
             submitCount,
             errors,
-            isSubmitting }) => (
+            isSubmitting
+          }) => (
             <div className="tab-panel">
-              {showCopyDialog ? <CopyDialog service_id={service_id} show={showCopyDialog} toggleCopyDialog={toggleCopyDialog} current_environment={props.initialValues.integration_environment} /> : null}
-              {serviceMoveEnabled && showMoveDialog ? <MoveDialog service_id={service_id} show={showMoveDialog} toggleMoveDialog={toggleMoveDialog} current_environment={props.initialValues.integration_environment} /> : null}
+              {showCopyDialog ? (
+                <CopyDialog
+                  service_id={service_id}
+                  show={showCopyDialog}
+                  toggleCopyDialog={toggleCopyDialog}
+                  current_environment={props.initialValues.integration_environment}
+                />
+              ) : null}
+              {serviceMoveEnabled && showMoveDialog ? (
+                <MoveDialog
+                  service_id={service_id}
+                  show={showMoveDialog}
+                  toggleMoveDialog={toggleMoveDialog}
+                  current_environment={props.initialValues.integration_environment}
+                />
+              ) : null}
               <ProcessingRequest active={asyncResponse} />
-              {props.user.actions.includes('manage_tags') && service_id ?
-                <div className='service-form-tags-container'>
+              {props.user.actions.includes('manage_tags') && service_id ? (
+                <div className="service-form-tags-container">
                   <hr />
                   <h5>Tags</h5>
                   <OverlayTrigger
-                    placement='top'
+                    placement="top"
                     overlay={
                       <Tooltip id={`tooltip-top`}>
                         Manage Service Tags
                       </Tooltip>
                     }
                   >
-                    <div className="service-form-tags-edit" onClick={() => { setManageTags(true) }}><FontAwesomeIcon icon={faPen} /></div>
+                    <div
+                      className="service-form-tags-edit"
+                      onClick={() => {
+                        setManageTags(true);
+                      }}
+                    >
+                      <FontAwesomeIcon icon={faPen} />
+                    </div>
                   </OverlayTrigger>
-                  <Form.Text className="text-mute"> Tags can be used to filter service search results </Form.Text>
+                  <Form.Text className="text-mute">
+                    {' '}
+                    Tags can be used to filter service search results{' '}
+                  </Form.Text>
                   <div className="service-form-tags-button-container">
-                    {serviceTags.length > 0 ? serviceTags.map((tag, index) => {
-                      return (
-                        <Button key={index} className="tag-button-service-form" disabled variant="outline-dark">{tag}</Button>
-                      )
-                    }) : <span className="text-muted">No active tags for this service</span>}
+                    {serviceTags.length > 0 ? (
+                      serviceTags.map((tag, index) => {
+                        return (
+                          <Button
+                            key={index}
+                            className="tag-button-service-form"
+                            disabled
+                            variant="outline-dark"
+                          >
+                            {tag}
+                          </Button>
+                        );
+                      })
+                    ) : (
+                      <span className="text-muted">
+                        No active tags for this service
+                      </span>
+                    )}
                   </div>
                   <hr />
-                </div> : null}
-              {showInitErrors && !Object.keys(errors).length === 0 ?
-                <Alert variant='warning' className="invitation_alert">
-                  The following Service Configuration contains some invalid values or is missing a required field. To fix this issue submit a valid reconfiguration request
-                </Alert>
-                : null
-              }
-              <Form noValidate onSubmit={handleSubmit}>
-                {props.disabled ? null :
-                  <div className="form-controls-container">
-                    {props.review ?
-                      <ReviewComponent errors={errors} asyncErrors={metadataAsyncError} disabled={metadataLoading} values={values} changes={props.changes} reviewPetition={reviewPetition} type={props.type} restrictReview={restrictReview} />
-                      :
-                      <React.Fragment>
-                        <div className="form-submit-cancel-container">
-                          <Button className='submit-button' type="submit" disabled={submitDisabled || metadataLoading || checkingAvailability} variant="primary" ><FontAwesomeIcon icon={faCheckCircle} />{t('button_submit')}</Button>
-                          {petition_id ? <Button variant="danger" onClick={() => deletePetition()}><FontAwesomeIcon icon={faBan} />{t('button_cancel_request')}</Button> : null}
-                        </div>
-                      </React.Fragment>
-                    }
-                  </div>
-                }
-                <div className="form-tabs-container">
-                  <Tabs className="form-tabs " defaultActiveKey="general" id="uncontrolled-tab-example">
-
-                    <Tab eventKey="general" title={t('form_tab_general')}>
-
-                      <InputRow moreInfo={tenant.form_config.more_info.service_name} title={t('form_service_name')} required={true} description={t('form_service_name_desc')} error={errors.service_name} touched={touched.service_name}>
-                        <SimpleInput
-                          name='service_name'
-                          placeholder={t('form_type_prompt')}
-                          onChange={handleChange}
-                          value={values.service_name}
-                          isInvalid={hasSubmitted ? !!errors.service_name : (!!errors.service_name && touched.service_name)}
-                          onBlur={handleBlur}
-                          disabled={disabled}
-                          changed={props.changes ? props.changes.service_name : null}
-                        />
-                      </InputRow>
-                      <InputRow moreInfo={tenant.form_config.more_info.integration_environment} title={t('form_integration_environment')} required={true} extraClass='select-col' error={errors.integration_environment} touched={touched.integration_environment}>
-                        <SelectEnvironment
-                          onBlur={handleBlur}
-                          optionsTitle={capitalWords(tenant.form_config.integration_environment)}
-                          options={tenant.form_config.integration_environment}
-                          name="integration_environment"
-                          values={values}
-                          isInvalid={hasSubmitted ? !!errors.integration_environment : (!!errors.integration_environment && touched.integration_environment)}
-                          onChange={handleChange}
-                          disabled={disabled || tenant.form_config.integration_environment.length === 1 || props.copy || props.disableEnvironment}
-                          changed={props.changes ? props.changes.integration_environment : null}
-                          copybuttonActive={props.owned && props.disabled && service_id}
-                          toggleCopyMoveDialog={serviceMoveEnabled ? toggleMoveDialog : toggleCopyDialog}
-                          moveInsteadCopy={serviceMoveEnabled}
-                        />
-                      </InputRow>
-                      <InputRow moreInfo={{}} title={t('form_logo')}>
-                        <LogoInput
-                          value={values.logo_uri ? values.logo_uri : ''}
-                          name='logo_uri'
-                          description={t('form_logo_desc')}
-                          moreInfo={tenant.form_config.more_info.logo_uri}
-                          onChange={handleChange}
-                          error={errors.logo_uri}
-                          touched={touched.logo_uri}
-                          onBlur={handleBlur}
-                          validateField={validateField}
-                          isInvalid={hasSubmitted ? !!errors.logo_uri : (!!errors.logo_uri && touched.logo_uri)}
-                          disabled={disabled}
-                          warning={logoWarning}
-                          changed={props.changes ? props.changes.logo_uri : null}
-                        />
-                      </InputRow>
-                      <InputRow moreInfo={tenant.form_config.more_info.website_url} title={t('form_website_url')} description={t('form_website_url_desc')} error={errors.website_url} touched={touched.website_url}>
-                        <SimpleInput
-                          name='website_url'
-                          placeholder={t('form_url_placeholder')}
-                          onChange={handleChange}
-                          value={values.website_url}
-                          isInvalid={hasSubmitted ? !!errors.website_url : (!!errors.website_url && touched.website_url)}
-                          onBlur={handleBlur}
-                          disabled={disabled}
-                          changed={props.changes ? props.changes.website_url : null}
-                        />
-                        <UrlWarning url={values.website_url} touched={hasSubmitted || touched.website_url} />
-                      </InputRow>
-
-                      <InputRow moreInfo={tenant.form_config.more_info.service_description} title={t('form_description')} required={true} description={t('form_description_desc')} error={errors.service_description} touched={touched.service_description}>
-                        <TextAria
-                          value={values.service_description ? values.service_description : ''}
-                          onChange={handleChange}
-                          onBlur={handleBlur}
-                          name='service_description'
-                          placeholder={t('form_type_prompt')}
-                          isInvalid={hasSubmitted ? !!errors.service_description : (!!errors.service_description && touched.service_description)}
-                          disabled={disabled}
-                          changed={props.changes ? props.changes.service_description : null}
-                        />
-                      </InputRow>
-                      <InputRow moreInfo={tenant.form_config.more_info.country} title={'Select country'} required={tenant?.form_config?.more_info?.country?.required.includes(values.integration_environment)} extraClass='select-col' error={errors.country} touched={touched.country}>
-                        <CountrySelect
-                          onBlur={handleBlur}
-                          placeholder={'Select country'}
-                          name="country"
-                          values={values}
-                          isInvalid={hasSubmitted ? !!errors.country : (!!errors.country && touched.country)}
-                          onChange={handleChange}
-                          disabled={disabled}
-                          changed={props.changes ? props.changes.country : null}
-                        />
-                      </InputRow>
-                      {tenant.form_config.extra_fields.organization && !tenant?.form_config?.extra_fields?.organization?.hide.includes(values.integration_environment) ?
-                        <React.Fragment>
-                          <InputRow moreInfo={tenant.form_config.more_info.organization_name} required={tenant.form_config.extra_fields.organization.required.includes(values.integration_environment)} title="Organisation" description="Search for your organisation" error={errors.organization_name} touched={touched.organization_name}>
-                            <OrganizationField
-                              name='organization_name'
-                              placeholder='Type the name of your organization'
-                              onChange={handleChange}
-                              values={values}
-                              isInvalid={hasSubmitted ? !!errors.organization_name : (!!errors.organization_name && touched.organization_name)}
-                              setFieldTouched={setFieldTouched}
-                              validateForm={validateForm}
-                              validateField={validateField}
-                              disabled={disabled}
-                              setFieldValue={setFieldValue}
-                              setDisabledOrganizationFields={setDisabledOrganizationFields}
-                              changed={props.changes ? props.changes.organization_name : null}
-                            />
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.organization_url} title="Organisation Website URL" required={tenant.form_config.extra_fields.organization.required.includes(values.integration_environment)} description="Link to the organization's website" error={errors.organization_url} touched={touched.organization_url}>
-                            <SimpleInput
-                              name='organization_url'
-                              placeholder={t('form_type_prompt')}
-                              onChange={handleChange}
-                              value={values.organization_url}
-                              isInvalid={hasSubmitted ? !!errors.organization_url : (!!errors.organization_url && touched.organization_url)}
-                              onBlur={handleBlur}
-                              disabled={disabled || disabledOrganizationFields.includes('organization_url')}
-                              changed={props.changes ? props.changes.organization_url : null}
-                            />
-                          </InputRow>
-
-                        </React.Fragment>
-                        : null
-                      }
-                      <InputRow moreInfo={tenant.form_config.more_info.policy_uri} title={t('form_policy_uri')} required={tenant.form_config.more_info.policy_uri?.required?.includes(values.integration_environment)} description={t('form_policy_uri_desc')} error={errors.policy_uri} touched={touched.policy_uri}>
-                        <SimpleInput
-                          name='policy_uri'
-                          placeholder={t('form_url_placeholder')}
-                          onChange={handleChange}
-                          value={values.policy_uri}
-                          isInvalid={hasSubmitted ? !!errors.policy_uri : (!!errors.policy_uri && touched.policy_uri)}
-                          onBlur={handleBlur}
-                          disabled={disabled}
-                          changed={props.changes ? props.changes.policy_uri : null}
-                        />
-                        <UrlWarning url={values.policy_uri} touched={hasSubmitted || touched.policy_uri} />
-                      </InputRow>
-
-
-
-
-                      {Object.entries(tenant.form_config.extra_fields).map(([name, field_data]) => {
-                        field_data.name = name;
-                        return (field_data.tab === 'general' && field_data.tag !== 'once' ? <React.Fragment key={name}>
-                          {generateInput({
-                            field_data,
-                            initialValues: props.initialValues,
-                            values,
-                            errors,
-                            touched,
-                            changes: props.changes,
-                            handleChange,
-                            hasSubmitted,
-                            disabled,
-                            handleBlur,
-                            tenant
-                          })}
-                        </React.Fragment> : null)
-                      })
-                      }
-
-
-
-
-                      <InputRow moreInfo={tenant.form_config.more_info.contacts} title={t('form_contacts')} required={true} error={typeof (errors.contacts) === 'string' ? errors.contacts : null} touched={touched.contacts} description={t('form_contacts_desc')}>
-                        <Contacts
-                          values={values.contacts}
-                          placeholder={t('form_type_prompt')}
-                          name='contacts'
-                          empty={typeof (errors.contacts) === 'string' ? true : false}
-                          error={errors.contacts}
-                          touched={touched.contacts}
-                          onChange={handleChange}
-                          onBlur={handleBlur}
-                          setFieldTouched={setFieldTouched}
-                          disabled={disabled}
-                          changed={props.changes ? props.changes.contacts : null}
-                        />
-                      </InputRow>
-
-
-                      {Object.entries(tenant.form_config.extra_fields).map(([name, field_data]) => {
-                        field_data.name = name;
-                        return (field_data.tab === 'general' && field_data.tag === 'once' ? <React.Fragment key={name}>
-                          {generateInput({
-                            field_data,
-                            initialValues: props.initialValues,
-                            values,
-                            errors,
-                            touched,
-                            changes: props.changes,
-                            handleChange,
-                            hasSubmitted,
-                            disabled,
-                            handleBlur,
-                            tenant
-                          })}
-                        </React.Fragment> : null)
-                      })
-                      }
-                    </Tab>
-                    <Tab eventKey="protocol" title={t('form_tab_protocol')}>
-                      <InputRow title={t('form_protocol')} required={true} extraClass='select-col' error={errors.protocol} touched={touched.protocol}>
-                        <Select
-                          onBlur={handleBlur}
-                          optionsTitle={['Select one option', ...protocolOptions(tenant.form_config.protocol)]}
-                          options={['', ...tenant.form_config.protocol]}
-                          name="protocol"
-                          values={values}
-                          isInvalid={hasSubmitted ? !!errors.protocol : (!!errors.protocol && touched.protocol)}
-                          onChange={handleChange}
-                          disabled={disabled || props.initialValues.protocol}
-                          changed={props.changes ? props.changes.protocol : null}
-                        />
-                      </InputRow>
-                      {values.protocol === 'oidc' ?
-                        <React.Fragment>
-
-                          <InputRow moreInfo={tenant.form_config.more_info.client_id} title={t('form_client_id')} description={t('form_client_id_desc')} error={checkingAvailability ? null : errors.client_id} touched={touched.client_id}>
-                            <SimpleInput
-                              name='client_id'
-                              placeholder={t('form_type_prompt')}
-                              onChange={(e) => {
-                                setFieldTouched('client_id');
-                                handleChange(e);
-                              }}
-                              copybutton={props.copybutton}
-                              value={values.client_id}
-                              isInvalid={hasSubmitted ? (!!errors.client_id && !checkingAvailability) : (!!errors.client_id && touched.client_id && !checkingAvailability)}
-                              onBlur={handleBlur}
-                              disabled={disabled || service_id}
-                              changed={props.changes ? props.changes.client_id : null}
-                              isloading={values.client_id && values.client_id !== checkedId && checkingAvailability ? 1 : 0}
-                            />
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.application_type} title={'Application Type'} required={true} description={""} error={errors.application_type} touched={touched.application_type}>
-                            <SimpleRadio
-                              name='application_type'
-                              onChange={handleChange}
-                              values={values}
-                              radio_items={['WEB', 'NATIVE']}
-                              setFieldValue={setFieldValue}
-                              radio_items_titles={['Web', 'Native']}
-                              value={values.application_type}
-                              isInvalid={hasSubmitted ? (!!errors.application_type) : (!!errors.application_type && touched.application_type && !checkingAvailability)}
-                              onBlur={handleBlur}
-                              className={'application-type-container'}
-                              disabled={disabled}
-                              changed={props.changes ? props.changes.application_type : null}
-                            />
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.grant_types} title={t('form_grant_types')} error={errors.grant_types} touched={true}>
-                            <CheckboxList
-                              name='grant_types'
-                              values={values.grant_types}
-                              listItems={tenant.form_config.grant_types}
-                              disabled={disabled}
-                              deprecated_options={tenant.form_config.grant_types_deprecated}
-                              changed={props.changes ? props.changes.grant_types : null}
-                            />
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.token_endpoint_auth_method} title="Token Endpoint Authorization Method" required={true} error={errors.token_endpoint_auth_method || errors.code_challenge_method} touched={touched.token_endpoint_auth_method}>
-                            <AuthMethRadioList
-                              name='token_endpoint_auth_method'
-                              values={values}
-                              setFieldValue={setFieldValue}
-                              onChange={handleChange}
-                              radio_items={tenant.form_config.token_endpoint_auth_method}
-                              radio_items_titles={tenant.form_config.token_endpoint_auth_method_title}
-                              disabled={disabled}
-                              changed={props.changes ? props.changes.token_endpoint_auth_method : null}
-                            />
-                          </InputRow>
-                          {!(values.token_endpoint_auth_method === 'private_key_jwt' || values.token_endpoint_auth_method === 'none') ?
-                            <InputRow moreInfo={tenant.form_config.more_info.client_secret} required={true} title={t('form_client_secret')}>
-                              <ClientSecret
-                                onChange={handleChange}
-                                client_secret={values.client_secret}
-                                error={errors.client_secret}
-                                touched={touched.client_secret}
-                                copybutton={props.copybutton}
-                                isInvalid={hasSubmitted ? !!errors.client_secret : (!!errors.client_secret && touched.client_secret)}
-                                onBlur={handleBlur}
-                                generate_client_secret={values.generate_client_secret}
-                                disabled={disabled}
-                                changed={props.changes ? props.changes.client_secret : null}
-                              />
-                            </InputRow>
-                            : null}
-                          {values.token_endpoint_auth_method === 'private_key_jwt' || values.token_endpoint_auth_method === 'client_secret_jwt' ?
-                            <InputRow moreInfo={tenant.form_config.more_info.token_endpoint_auth_signing_alg} title="Token Endpoint Signing Algorithm" required={true} extraClass='select-col' error={errors.token_endpoint_auth_signing_alg} touched={touched.token_endpoint_auth_signing_alg}>
-                              <Select
-                                onBlur={handleBlur}
-                                optionsTitle={tenant.form_config.token_endpoint_auth_signing_alg_title}
-                                options={tenant.form_config.token_endpoint_auth_signing_alg}
-                                default='RS256'
-                                name="token_endpoint_auth_signing_alg"
-                                values={values}
-                                isInvalid={hasSubmitted ? !!errors.token_endpoint_auth_signing_alg_title : (!!errors.token_endpoint_auth_signing_alg && touched.token_endpoint_auth_signing_alg)}
-                                onChange={handleChange}
-                                disabled={disabled}
-                                changed={props.changes ? props.changes.token_endpoint_auth_signing_alg : null}
-                              />
-                            </InputRow>
-                            : null}
-                          {values.token_endpoint_auth_method === 'private_key_jwt' ?
-                            <InputRow moreInfo={tenant.form_config.more_info.jwks} title="Public Key Set" required={true} extraClass='select-col' description="URL for the client's JSON Web Key set (must be reachable by the server)" error={errors.jwks ? errors.jwks : errors.jwks_uri} touched={touched.jwks || touched.jwks_uri}>
-                              <PublicKey
-                                onBlur={handleBlur}
-                                values={values}
-                                setvalue={(field, value, validate) => setFieldValue(field, value, validate)}
-                                isInvalid={hasSubmitted ? errors.jwks_uri || errors.jwks : ((errors.jwks_uri || errors.jwks) && (touched.jwks || touched.jwks_uri))}
-                                datatype="json"
-                                onChange={handleChange}
-                                disabled={disabled}
-                                changed={props.changes && (props.changes.jwks || props.changes.jwks_uri) ? true : false}
-                              />
-                            </InputRow>
-                            : null}
-                          <InputRow moreInfo={tenant.form_config.more_info.allow_introspection} title={t('form_allow_introspection')}>
-                            <div className='simple_checkbox_container'>
-                              <SimpleCheckbox
-                                name='allow_introspection'
-                                label={t('form_allow_introspection_desc')}
-                                onChange={handleChange}
-                                moreinfo={tenant.form_config.more_info.allow_introspection}
-                                disabled={disabled || tenant.form_config.dynamic_fields.includes('allow_introspection')}
-                                value={values.allow_introspection}
-                                changed={props.changes ? props.changes.allow_introspection : null}
-                              />
-                            </div>
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.scope} title={t('form_scope')} required={values?.grant_types?.length>0} description={t('form_scope_desc')} error={typeof (errors.scope) === 'string' ? errors.scope : null} touched={true}>
-                            <ListInputArray
-                              name='scope'
-                              values={values.scope}
-                              placeholder={t('form_type_prompt')}
-                              defaultValues={tenant.form_config.scope}
-                              error={errors.scope}
-                              touched={touched.scope}
-                              disabled={disabled}
-                              onBlur={handleBlur}
-                              changed={props.changes ? props.changes.scope : null}
-                            />
-                          </InputRow> 
-                          <InputRow moreInfo={tenant.form_config.more_info.redirect_uris} title={t('form_redirect_uris')} required={values?.grant_types?.includes("implicit") || values?.grant_types?.includes("authorization_code")} error={typeof (errors.redirect_uris) === 'string' ? errors.redirect_uris : null} touched={touched.redirect_uris} description={t('form_redirect_uris_desc')}>
-                            <ListInput
-                              values={values.redirect_uris}
-                              placeholder={t('form_type_prompt')}
-                              empty={(typeof (errors.redirect_uris) === 'string') ? true : false}
-                              name='redirect_uris'
-                              error={errors.redirect_uris}
-                              touched={touched.redirect_uris}
-                              onBlur={handleBlur}
-                              onChange={handleChange}
-                              integrationEnvironment={values.integration_environment}
-                              setFieldTouched={setFieldTouched}
-                              disabled={disabled}
-                              changed={props.changes ? props.changes.redirect_uris : null}
-                            />
-                          </InputRow>
-                          {!tenant.form_config.disabled_fields.includes("post_logout_redirect_uris") ?
-                            <InputRow moreInfo={tenant.form_config.more_info.post_logout_redirect_uris} title={t('form_redirect_uris')} error={typeof (errors.post_logout_redirect_uris) === 'string' ? errors.post_logout_redirect_uris : null} touched={touched.post_logout_redirect_uris} description={t('form_redirect_uris_desc')}>
-                              <ListInput
-                                values={values.post_logout_redirect_uris}
-                                placeholder={t('form_type_prompt')}
-                                empty={(typeof (errors.post_logout_redirect_uris) === 'string') ? true : false}
-                                name='post_logout_redirect_uris'
-                                error={errors.post_logout_redirect_uris}
-                                touched={touched.post_logout_redirect_uris}
-                                onBlur={handleBlur}
-                                onChange={handleChange}
-                                integrationEnvironment={values.integration_environment}
-                                setFieldTouched={setFieldTouched}
-                                disabled={disabled}
-                                changed={props.changes ? props.changes.post_logout_redirect_uris : null}
-                              />
-                            </InputRow> : null
-                          }
-                          <InputRow moreInfo={tenant.form_config.more_info.code_challenge_method} required={true} title={t('form_code_challenge_method')} extraClass='select-col' error={errors.code_challenge_method} touched={touched.code_challenge_method}>
-                            <Select
-                              onBlur={handleBlur}
-                              optionsTitle={['PKCE will not be used for this service ' + (values.grant_types && values.grant_types.includes('authorization_code') ? '(disabled)' : ''), 'Plain code challenge (deprecated)', 'SHA-256 hash algorithm (recommended)']}
-                              options={['', 'plain', 'S256']}
-                              name="code_challenge_method"
-                              values={values}
-                              isInvalid={hasSubmitted ? !!errors.code_challenge_method : (!!errors.code_challenge_method && touched.code_challenge_method)}
-                              onChange={handleChange}
-                              setFieldValue={(value) => { setFieldValue('code_challenge_method', value); }}
-                              recommended={'S256'}
-                              disabled={disabled}
-                              default={values.code_challenge_method ? values.code_challenge_method : ''}
-                              changed={props.changes ? props.changes.code_challenge_method : null}
-                            />
-                            <div className='pkce-tooltip'>
-                              <FontAwesomeIcon icon={faExclamationTriangle} />
-                              Enabling PKCE is highly recommended to avoid code injection and code replay attacks. If enabled, you need to make sure that your client uses PKCE to prevent errors
-                            </div>
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.refresh_token_validity_seconds} required={values.scope?.includes('offline_access')} title={t('form_refresh_token_validity_seconds')} extraClass='time-input' error={errors.refresh_token_validity_seconds} touched={touched.refresh_token_validity_seconds}>
-                            <RefreshToken
-                              values={values}
-                              onBlur={handleBlur}
-                              isInvalid={hasSubmitted ? !!errors.refresh_token_validity_seconds : (!!errors.refresh_token_validity_seconds && touched.refresh_token_validity_seconds)}
-                              onChange={handleChange}
-                              disabled={disabled}
-                              errors={errors}
-                              description={`${t('form_refresh_token_validity_seconds_desc')} ${t('min_value_is')} ${formatDuration(
-                                  tenant.form_config.more_info?.refresh_token_validity_seconds?.min ?? 1
-                                )}. ${t('max_value_is')} ${formatDuration(
-                                  tenant.form_config.more_info?.refresh_token_validity_seconds?.max ??
-                                  tenant.form_config.refresh_token_validity_seconds ??
-                                  34560000
-                                )}.`}
-                              setFieldValue={setFieldValue}
-                              validateField={validateField}
-                              changed={props.changes}
-                            />
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.device_code_validity_seconds} required={values?.grant_types?.includes('urn:ietf:params:oauth:grant-type:device_code')} title={t('form_device_code_validity_seconds')} extraClass='time-input' error={errors.device_code_validity_seconds} touched={touched.device_code_validity_seconds}>
-                            <DeviceCode
-                              onBlur={handleBlur}
-                              values={values}
-                              setFieldValue={setFieldValue}
-                              errors={errors}
-                              validateField={validateField}
-                              isInvalid={hasSubmitted ? !!errors.device_code_validity_seconds : (!!errors.device_code_validity_seconds && touched.device_code_validity_seconds)}
-                              onChange={handleChange}
-                              disabled={disabled}
-                              changed={props.changes}
-                            />
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.access_token_validation_model} required={true} title={t('form_access_token_validation_model')} error={errors.access_token_validation_model} touched={touched.access_token_validation_model}>
-                              <AccessTokenValidationModel
-                                name="access_token_validation_model"
-                                values={values}
-                                setFieldValue={setFieldValue}
-                                disabled={disabled}
-                                changed={props.changes ? props.changes.access_token_validation_model : null}
-                                limits={tenant.form_config.more_info.access_token_validity_seconds.max}
-                              />
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.access_token_validity_seconds} required={true} title={t('form_access_token_validity_seconds')} extraClass='time-input' error={errors.access_token_validity_seconds} touched={touched.access_token_validity_seconds} 
-                            description={`${t('form_access_token_validity_seconds_desc')} ${t('min_value_is')} ${formatDuration(
-                              tenant.form_config.more_info?.access_token_validity_seconds?.min ?? 1
-                            )}. ${t('max_value_is')} ${formatDuration(
-                              tenant.form_config.more_info?.access_token_validity_seconds?.max?.[
-                                values.access_token_validation_model || 'OFFLINE_VERIFIABLE'
-                              ] ??
-                              tenant.form_config.more_info?.access_token_validity_seconds?.max
-                                ?.OFFLINE_VERIFIABLE ??
-                              tenant.form_config.access_token_validity_seconds ??
-                              21600
-                            )}.`}
-                          >
-                            <TimeInput
-                              name='access_token_validity_seconds'
-                              value={values.access_token_validity_seconds}
-                              isInvalid={hasSubmitted ? !!errors.access_token_validity_seconds : (!!errors.access_token_validity_seconds && touched.access_token_validity_seconds)}
-                              onBlur={handleBlur}
-                              onChange={handleChange}
-                              disabled={disabled}
-                              changed={props.changes ? props.changes.access_token_validity_seconds : null}
-                            />
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.id_token_timeout_seconds} required={true} title={t('form_id_token_timeout_seconds')} extraClass='time-input' error={errors.id_token_timeout_seconds} touched={touched.id_token_timeout_seconds} description={t('form_id_token_timeout_seconds_desc')}>
-                            <TimeInput
-                              name='id_token_timeout_seconds'
-                              value={values.id_token_timeout_seconds}
-                              isInvalid={hasSubmitted ? !!errors.id_token_timeout_seconds : (!!errors.id_token_timeout_seconds && touched.id_token_timeout_seconds)}
-                              onBlur={handleBlur}
-                              onChange={handleChange}
-                              disabled={disabled}
-                              changed={props.changes ? props.changes.id_token_timeout_seconds : null}
-                            />
-                          </InputRow>
-                        </React.Fragment>
-                        : null}
-                      {values.protocol === 'saml' ?
-                        <React.Fragment>
-                          <ConfirmationModal
-                            active={metadataLoaded.supported_attributes.length > 0 || (metadataLoaded.entity_id && (!values.entity_id || values.entity_id !== metadataLoaded.entity_id)) ? true : false}
-                            close={() => {
-                              if (metadataLoaded.supported_attributes.length > 0) {
-                                setMetadataLoaded({ ...metadataLoaded, supported_attributes: [] });
-                              }
-                              else if (metadataLoaded.entity_id) {
-                                setMetadataLoaded({ ...metadataLoaded, entity_id: "" });
-                              }
-                            }}
-                            action={() => {
-                              if (metadataLoaded.supported_attributes.length > 0) {
-                                setFieldValue('requested_attributes', metadataLoaded.supported_attributes)
-                                setMetadataLoaded({ ...metadataLoaded, supported_attributes: [] });
-                              }
-                              else {
-                                setFieldValue('entity_id', metadataLoaded.entity_id);
-                                setMetadataLoaded({ ...metadataLoaded, entity_id: "" });
-                              }
-                            }}
-                            title={
-                              metadataLoaded.supported_attributes.length > 0 ? "Do you wish to load the requested attributes contained in the Metadata Url?" :
-                                metadataLoaded.entity_id && !values.entity_id ? "Do you wish to use the Entity Id contained in the Metadata Url?" :
-                                  metadataLoaded.entity_id && metadataLoaded.entity_id !== values.entity_id ? "The Metadata Url contains a different Entity Id from the provided, do you wish to replace it?" : ""
-                            }
-                            message={
-                              metadataLoaded.supported_attributes.length > 0 ? metadataLoaded.supported_attributes.length + (metadataLoaded.unsupported_attributes.length > 0 ? " out of " + (metadataLoaded.supported_attributes.length + metadataLoaded.unsupported_attributes.length) : "") + " attributes found are supported and can be added in the service configuration." :
-                                metadataLoaded.entity_id && (!values.entity_id || metadataLoaded.entity_id !== values.entity_id) ? "Entity Id: " + metadataLoaded.entity_id :
-                                  null}
-                            accept={'Yes'}
-                            decline={'No'} />
-                          <InputRow moreInfo={tenant.form_config.more_info.entity_id} required={true} title={t('form_entity_id')} description={t('form_entity_id_desc')} error={checkingAvailability ? null : errors.entity_id} touched={touched.entity_id}>
-                            <SimpleInput
-                              name='entity_id'
-                              placeholder={t('form_type_prompt')}
-                              onChange={(e) => {
-                                setFieldTouched('entity_id');
-                                handleChange(e);
-                              }}
-                              value={values.entity_id}
-                              copybutton={props.copybutton}
-                              isInvalid={hasSubmitted ? !!(errors.entity_id && !checkingAvailability) : (!!errors.entity_id && touched.entity_id && !checkingAvailability)}
-                              onBlur={handleBlur}
-                              disabled={disabled || service_id}
-                              changed={props.changes ? props.changes.entity_id : null}
-                              isloading={values.entity_id && values.entity_id !== checkedId && checkingAvailability ? 1 : 0}
-                            />
-                          </InputRow>
-                          <InputRow moreInfo={tenant.form_config.more_info.metadata_url} required={true} title={t('form_metadata_url')} description={t('form_metadata_url_desc')} error={metadataAsyncError || errors.metadata_url} touched={touched.metadata_url}>
-                            <MetadataInput
-                              name='metadata_url'
-                              placeholder='Type something'
-                              onChange={(e) => {
-                                setMetadataAyncError('');
-                                setMetadataWarning();
-                                handleChange(e);
-                              }}
-                              copybutton={props.copybutton}
-                              value={values.metadata_url}
-                              isInvalid={hasSubmitted ? !!metadataAsyncError || !!errors.metadata_url : ((!!metadataAsyncError || !!errors.metadata_url) && touched.metadata_url)}
-                              onBlur={handleBlur}
-                              disabled={disabled}
-                              getmetadata={(metadata_url) => {
-                                getMetadata(metadata_url, null, (attributes) => { setFieldValue('requested_attributes', attributes, false) });
-                              }}
-                              changed={props.changes ? props.changes.metadata_url : null}
-                              isloading={values.metadata_url && metadataLoading ? 1 : 0}
-                            />
-                            <UrlWarning url={values.metadata_url} overwriteWarning={metadataWarning} disableCheck={1} touched={!!values.metadata_url} />
-                          </InputRow>
-                          {!tenant.form_config.more_info.requested_attributes.disabled ?
-                            <InputRow moreInfo={tenant.form_config.more_info.requested_attributes} title={tenant.form_config.more_info.requested_attributes.label || "Attributes"} required={false} description={tenant.form_config.more_info.requested_attributes.description} error={typeof (errors.scope) === 'string' ? errors.scope : null} touched={true}>
-                              <SamlAttributesInput
-                                name='requested_attributes'
-                                values={values.requested_attributes ? values.requested_attributes : []}
-                                placeholder={t('form_type_prompt')}
-                                defaultValues={tenant.form_config.requested_attributes}
-                                errors={errors.requested_attributes}
-                                touched={touched.requested_attributes}
-                                setMetadataLoaded={setMetadataLoaded}
-                                disabled={disabled}
-                                setFieldValue={setFieldValue}
-                                onBlur={handleBlur}
-                                changed={props.changes ? props.changes.requested_attributes : null}
-                              />
-                            </InputRow>
-                            : null
-                          }
-                        </React.Fragment>
-                        : null}
-                    </Tab>
-                  </Tabs>
                 </div>
-                {props.disabled ? null :
+              ) : null}
+              {showInitErrors && !Object.keys(errors).length === 0 ? (
+                <Alert variant="warning" className="invitation_alert">
+                  The following Service Configuration contains some invalid
+                  values or is missing a required field. To fix this issue submit
+                  a valid reconfiguration request
+                </Alert>
+              ) : null}
+              <Form noValidate onSubmit={handleSubmit}>
+                {props.disabled ? null : (
                   <div className="form-controls-container">
-                    {props.review ?
-                      <ReviewComponent errors={errors} disabled={metadataLoading} asyncErrors={metadataAsyncError} values={values} changes={props.changes} type={props.type} reviewPetition={reviewPetition} restrictReview={restrictReview} />
-                      :
+                    {props.review ? (
+                      <ReviewComponent
+                        errors={errors}
+                        asyncErrors={metadataAsyncError}
+                        disabled={metadataLoading}
+                        values={values}
+                        changes={props.changes}
+                        reviewPetition={reviewPetition}
+                        type={props.type}
+                        restrictReview={restrictReview}
+                      />
+                    ) : (
                       <React.Fragment>
                         <div className="form-submit-cancel-container">
-                          <Button className='submit-button' type="submit" disabled={submitDisabled || metadataLoading || checkingAvailability} variant="primary" ><FontAwesomeIcon icon={faCheckCircle} />Submit</Button>
-                          {props.type === 'delete' || props.type === 'edit' ? <Button variant="danger" onClick={() => deletePetition()}><FontAwesomeIcon icon={faBan} />Cancel Request</Button> : null}
+                          <Button
+                            className="submit-button"
+                            type="submit"
+                            disabled={
+                              submitDisabled ||
+                              metadataLoading ||
+                              checkingAvailability
+                            }
+                            variant="primary"
+                          >
+                            <FontAwesomeIcon icon={faCheckCircle} />
+                            {t('button_submit')}
+                          </Button>
+                          {petition_id ? (
+                            <Button
+                              variant="danger"
+                              onClick={() => deletePetition()}
+                            >
+                              <FontAwesomeIcon icon={faBan} />
+                              {t('button_cancel_request')}
+                            </Button>
+                          ) : null}
                         </div>
                       </React.Fragment>
-                    }
+                    )}
                   </div>
+                )}
 
-                }
-                <PetitionSubmittedModal modalData={modalData} setModalData={setModalData} />
-                <SimpleModal isSubmitting={isSubmitting} isValid={!Object.keys(errors).length} />
-                {/* <Debug/> */}
+                {/* Refactored: Tabs rendered via ServiceFormTabs component */}
+                <ServiceFormTabs
+                  disabled={disabled}
+                  changes={props.changes}
+                  extraFields={tenant.form_config.extra_fields || {}}
+                />
 
+                {props.disabled ? null : (
+                  <div className="form-controls-container">
+                    {props.review ? (
+                      <ReviewComponent
+                        errors={errors}
+                        disabled={metadataLoading}
+                        asyncErrors={metadataAsyncError}
+                        values={values}
+                        changes={props.changes}
+                        type={props.type}
+                        reviewPetition={reviewPetition}
+                        restrictReview={restrictReview}
+                      />
+                    ) : (
+                      <React.Fragment>
+                        <div className="form-submit-cancel-container">
+                          <Button
+                            className="submit-button"
+                            type="submit"
+                            disabled={
+                              submitDisabled ||
+                              metadataLoading ||
+                              checkingAvailability
+                            }
+                            variant="primary"
+                          >
+                            <FontAwesomeIcon icon={faCheckCircle} />
+                            Submit
+                          </Button>
+                          {props.type === 'delete' ||
+                          props.type === 'edit' ? (
+                            <Button
+                              variant="danger"
+                              onClick={() => deletePetition()}
+                            >
+                              <FontAwesomeIcon icon={faBan} />
+                              Cancel Request
+                            </Button>
+                          ) : null}
+                        </div>
+                      </React.Fragment>
+                    )}
+                  </div>
+                )}
+                <PetitionSubmittedModal
+                  modalData={modalData}
+                  setModalData={setModalData}
+                />
+                <SimpleModal
+                  isSubmitting={isSubmitting}
+                  isValid={!Object.keys(errors).length}
+                />
               </Form>
-
-
-
-
             </div>
           )}
         </Formik>
-        : null}
+      ) : null}
     </React.Fragment>
   );
-}
+};
 
 const ReviewComponent = (props) => {
-
   const [type, setType] = useState();
   const [expand, setExpand] = useState(false);
   const [error, setError] = useState(false);
   const [comment, setComment] = useState();
   const [invalidPetition, setInvalidPetition] = useState(false);
-  // eslint-disable-next-line
   const { t, i18n } = useTranslation();
+
   useEffect(() => {
     let invalid = false;
     for (const attribute in props.errors) {
       if (Array.isArray(props.errors[attribute])) {
         for (let i = 0; i < props.errors[attribute].length; i++) {
-          if (props.errors[attribute][i] && !props.changes[attribute].D.includes(props.values[attribute][i])) {
+          if (
+            props.errors[attribute][i] &&
+            !props.changes[attribute].D.includes(props.values[attribute][i])
+          ) {
             invalid = true;
           }
         }
-      }
-      else {
-        invalid = true
+      } else {
+        invalid = true;
       }
     }
     setInvalidPetition(invalid || !!props.asyncErrors);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.errors]);
 
-
   const handleReview = () => {
-
     if (expand) {
       if (type) {
         if ((type === 'changes' && comment) || type !== 'changes') {
           props.reviewPetition(comment, type);
-        }
-        else {
+        } else {
           setError(t('review_comment_required_msg'));
         }
-      }
-      else {
+      } else {
         setError(t('review_select_option_msg'));
       }
     } else {
       setError(false);
       setExpand(true);
     }
-  }
+  };
+
   return (
     <React.Fragment>
       <Row className="review-button-row">
         <ButtonGroup>
-          <Button className="review-button" disabled={expand && props.disabled} variant="success" onClick={() => handleReview()}>{expand ? t('review_submit') :
-            <React.Fragment>
-              {t('review')}
+          <Button
+            className="review-button"
+            disabled={expand && props.disabled}
+            variant="success"
+            onClick={() => handleReview()}
+          >
+            {expand ? t('review_submit') : <React.Fragment>{t('review')}
               <FontAwesomeIcon icon={faSortDown} />
-            </React.Fragment>
-          }</Button>
-          {expand ?
-            <Button variant="success" className="review-button-expand" onClick={() => setExpand(!expand)}>
+            </React.Fragment>}
+          </Button>
+          {expand ? (
+            <Button
+              variant="success"
+              className="review-button-expand"
+              onClick={() => setExpand(!expand)}
+            >
               <FontAwesomeIcon icon={faSortDown} />
-            </Button> : null}
-
+            </Button>
+          ) : null}
         </ButtonGroup>
-        {error && expand ?
-          <div className="review-error">
-            {error}
-          </div>
-          : null}
-
       </Row>
-      <Collapse in={expand}>
-        <div className="expand-container">
-          <div className="review-controls flex-column">
-            <Form.Group>
-              {props.restrictReview ?
-                <Row>
-                  <Col md="auto" className="review-radio-col">
-                    <Form.Check
-                      type="radio"
-                      name="formHorizontalRadios"
-                      id="formHorizontalRadios4"
-                      onChange={(e) => { if (e.target.checked) { setType(e.target.value) } }}
-                      value="request_review"
-                      checked={type === 'request_review'}
-                    />
-                  </Col>
-                  <Col onClick={() => {
-                    setType('request_review');
-                  }}>
-                    <Row>
-                      <strong>
-                        {t('review_request_review')}
-                      </strong>
-                    </Row>
-                    <Row className="review-option-desc">
-                      {t('review_request_review_desc')}
-                    </Row>
-                  </Col>
-                </Row>
-                :
-                <Row>
-                  <Col md="auto" className="review-radio-col">
-                    <Form.Check
-                      type="radio"
-                      name="formHorizontalRadios"
-                      id="formHorizontalRadios1"
-                      disabled={invalidPetition && props.type !== 'delete'}
-                      onChange={(e) => { if (e.target.checked) { setType(e.target.value) } }}
-                      value="approve"
-                      checked={type === 'approve'}
-                    />
-                  </Col>
-                  <Col onClick={() => {
-                    if (!invalidPetition || props.type === 'delete') {
-                      setType('approve');
-                    }
-                  }}>
-                    <Row>
-                      <strong>
-                        {t('review_approve')}
-                      </strong>
-                      {invalidPetition && props.type !== 'delete' ?
-                        <div className="approve-error">
-                          Invalid Service Configuration, Approve disabled
-                        </div> : null
-                      }
-                    </Row>
-
-                    <Row className="review-option-desc">
-                      {t('review_approve_desc')}
-                    </Row>
-                  </Col>
-                </Row>
-              }
-              <Row>
-                <Col md="auto" className="review-radio-col">
-                  <Form.Check
-                    type="radio"
-                    name="formHorizontalRadios"
-                    id="formHorizontalRadios2"
-                    onChange={(e) => { if (e.target.checked) { setType(e.target.value) } }}
-                    value="reject"
-                    checked={type === 'reject'}
+      {expand ? (
+        <Collapse in={expand}>
+          <div>
+            <div className="review-collapse-container">
+              <Form.Group>
+                <Form.Label>Review Type</Form.Label>
+                <Form.Control
+                  as="select"
+                  value={type ? type : ''}
+                  onChange={(e) => setType(e.target.value)}
+                  isInvalid={error && !invalidPetition}
+                  disabled={props.disabled}
+                >
+                  <option value="">Select an option</option>
+                  <option value="changes">Changes</option>
+                  <option value="approved">Approved</option>
+                  <option value="rejected">Rejected</option>
+                </Form.Control>
+                <Form.Text className="text-muted">
+                  Select the type of review you want to submit
+                </Form.Text>
+              </Form.Group>
+              {type === 'changes' ? (
+                <Form.Group>
+                  <Form.Label>Comment</Form.Label>
+                  <Form.Control
+                    as="textarea"
+                    rows={3}
+                    value={comment ? comment : ''}
+                    onChange={(e) => setComment(e.target.value)}
+                    isInvalid={error && invalidPetition}
+                    disabled={props.disabled}
                   />
-                </Col>
-                <Col onClick={() => {
-                  setType('reject');
-                }}>
-                  <Row>
-                    <strong>
-                      {t('review_reject')}
-                    </strong>
-                  </Row>
-                  <Row className="review-option-desc">
-                    {t('review_reject_desc')}
-                  </Row>
-                </Col>
-              </Row>
-              <Row>
-                <Col md="auto" className="review-radio-col">
-                  <Form.Check
-                    type="radio"
-                    name="formHorizontalRadios"
-                    id="formHorizontalRadios3"
-                    onChange={(e) => { if (e.target.checked) { setType(e.target.value) } }}
-                    value="changes"
-                    checked={type === 'changes'}
-                  />
-                </Col>
-                <Col onClick={() => {
-                  setType('changes');
-                }}>
-                  <Row>
-                    <strong>
-                      {t('review_changes')}
-                    </strong>
-                  </Row>
-                  <Row className="review-option-desc">
-                    {t('review_changes_desc')}
-                  </Row>
-                </Col>
-              </Row>
-            </Form.Group>
+                  <Form.Text className="text-muted">
+                    Describe the changes that need to be made
+                  </Form.Text>
+                </Form.Group>
+              ) : null}
+              {error ? <Alert variant="danger">{error}</Alert> : null}
+              <Button
+                variant="success"
+                onClick={() => handleReview()}
+                disabled={props.disabled || (type === 'changes' && !comment)}
+              >
+                Submit Review
+              </Button>
+            </div>
           </div>
-
-          <Row>
-
-            <Form.Control
-              autoFocus
-              maxLength='1024'
-              as="textarea"
-              rows='7'
-              className="comment-input"
-              placeholder={t('review_comment_prompt')}
-              onChange={e => setComment(e.target.value)}
-              value={comment}
-            />
-
-          </Row>
-        </div>
-
-      </Collapse>
-
+        </Collapse>
+      ) : null}
     </React.Fragment>
   );
-}
-
-
-
-
+};
 
 const UrlWarning = (props) => {
   const [active, setActive] = useState(!!props.overwriteWarning);
-
 
   useEffect(() => {
     if (!props.overwriteWarning) {
@@ -1994,23 +1922,24 @@ const UrlWarning = (props) => {
       if (props.touched && props.url && reg.regSimpleUrl.test(props.url)) {
         const exists = async (url) => {
           const result = await fetch(url, {
-            method: 'HEAD', mode: 'no-cors'
+            method: 'HEAD',
+            mode: 'no-cors'
           });
           return result.ok;
-        }
+        };
         urlCheckTimeout = setTimeout(() => {
           urlCheckTimeoutResponse = setTimeout(() => {
             setActive(true);
             clearTimeout(urlCheckTimeout);
-          }, 3000)
-          exists(props.url).then(result => {
+          }, 3000);
+          exists(props.url).then((result) => {
             clearTimeout(urlCheckTimeoutResponse);
             setActive(false);
-          }).catch(err => {
+          }).catch((err) => {
             clearTimeout(urlCheckTimeoutResponse);
-            setActive(true)
+            setActive(true);
           });
-        }, 1000)
+        }, 1000);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -2018,44 +1947,32 @@ const UrlWarning = (props) => {
 
   return (
     <React.Fragment>
-      {(active && !props.disableCheck) || props.overwriteWarning ?
-        <div className='pkce-tooltip'>
+      {(active && !props.disableCheck) || props.overwriteWarning ? (
+        <div className="pkce-tooltip">
           <FontAwesomeIcon icon={faExclamationTriangle} />
-          {props.overwriteWarning || "Url could not be reached, make sure you have provided a valid url."}
-        </div> : null
-      }
+          {props.overwriteWarning
+            ? props.overwriteWarning
+            : 'The provided url does not seem to exist'}
+        </div>
+      ) : null}
     </React.Fragment>
-  )
-}
-function generateValues(data) {
-
-
-  if (data.generate_client_secret && data.protocol === 'oidc') {
-    data.client_secret = hex(87);
-    data.generate_client_secret = false;
-  }
-  return data
-}
-
-function hex(n) {
-  const validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
-  let array = new Uint8Array(n || 87);
-  window.crypto.getRandomValues(array);
-  array = array.map(x => validChars.charCodeAt(x % validChars.length));
-  const randomState = String.fromCharCode.apply(null, array);
-  return randomState;
-}
+  );
+};
 
 const generateInput = (props) => {
   return (
     <React.Fragment>
-      {props.field_data.type === 'boolean' ?
+      {props.field_data.type === 'boolean' ? (
         <InputRow
           moreInfo={props.tenant.form_config.more_info[props.field_data.name]}
           title={props.field_data.title}
           key={props.field_data.name}
-          required={props.field_data.required.includes(props.values.integration_environment)}
-          error={props.errors[props.field_data.name] ? props.errors[props.field_data.name] : null}
+          required={props.field_data.required.includes(
+            props.values.integration_environment
+          )}
+          error={props.errors[props.field_data.name]
+            ? props.errors[props.field_data.name]
+            : null}
           touched={props.touched[props.field_data.name]}
         >
           <SimpleCheckbox
@@ -2067,56 +1984,74 @@ const generateInput = (props) => {
             }
             moreinfo={props.tenant.form_config.more_info[props.field_data.name]}
             onChange={props.handleChange}
-            disabled={props.disabled || (props.field_data.tag === 'once' && props.initialValues[props.field_data.name])}
+            disabled={
+              props.disabled ||
+              (props.field_data.tag === 'once' &&
+                props.initialValues[props.field_data.name])
+            }
             value={props.values[props.field_data.name]}
             onBlur={props.handleBlur}
             changed={props.changes ? props.changes[props.field_data.name] : null}
           />
         </InputRow>
-        : props.field_data.type === 'string' ?
-          <InputRow
-            description={props.field_data.desc}
-            moreInfo={props.tenant.form_config.more_info[props.field_data.name]}
-            title={props.field_data.title}
-            key={props.field_data.name}
-            required={props.field_data.required.includes(props.values.integration_environment)}
-            error={props.errors[props.field_data.name] ? props.errors[props.field_data.name] : null}
-            touched={props.touched[props.field_data.name]}
-          >
-            <SimpleInput
-              name={props.field_data.name}
-              placeholder={props.field_data.placeholder}
-              onChange={props.handleChange}
-              value={props.values[props.field_data.name]}
-              isInvalid={props.hasSubmitted ? !!props.errors[props.field_data.name] : (!!props.errors[props.field_data.name] && props.touched[props.field_data.name])}
-              onBlur={props.handleBlur}
-              disabled={props.disabled}
-              changed={props.changes ? props.changes[props.field_data.name] : null}
+      ) : props.field_data.type === 'string' ? (
+        <InputRow
+          description={props.field_data.desc}
+          moreInfo={props.tenant.form_config.more_info[props.field_data.name]}
+          title={props.field_data.title}
+          key={props.field_data.name}
+          required={props.field_data.required.includes(
+            props.values.integration_environment
+          )}
+          error={props.errors[props.field_data.name]
+            ? props.errors[props.field_data.name]
+            : null}
+          touched={props.touched[props.field_data.name]}
+        >
+          <SimpleInput
+            name={props.field_data.name}
+            placeholder={props.field_data.placeholder}
+            onChange={props.handleChange}
+            value={props.values[props.field_data.name]}
+            isInvalid={props.hasSubmitted
+              ? !!props.errors[props.field_data.name]
+              : !!props.errors[props.field_data.name] &&
+                props.touched[props.field_data.name]}
+            onBlur={props.handleBlur}
+            disabled={props.disabled}
+            changed={props.changes ? props.changes[props.field_data.name] : null}
+          />
+          {props.field_data.tag === 'url' ? (
+            <UrlWarning
+              url={props.values[props.field_data.name]}
+              touched={props.hasSubmitted || props.touched[props.field_data.name]}
             />
-            {props.field_data.tag === 'url' ?
-              <UrlWarning url={props.values[props.field_data.name]} touched={props.hasSubmitted || props.touched[props.field_data.name]} /> : null}
-          </InputRow>
-          : null
-      }
-
+          ) : null}
+        </InputRow>
+      ) : null}
     </React.Fragment>
-  )
-}
-
+  );
+};
 
 function capitalWords(array) {
-  let return_array = array.map((item, index) => {
+  let return_array = array.map((item) => {
     var splitStr = item.toLowerCase().split(' ');
     for (var i = 0; i < splitStr.length; i++) {
-      // You do not need to check if i is larger than splitStr length, as your for does that for you
-      // Assign it back to the array
-      splitStr[i] = splitStr[i].charAt(0).toUpperCase() + splitStr[i].substring(1);
+      splitStr[i] =
+        splitStr[i].charAt(0).toUpperCase() + splitStr[i].substring(1);
     }
     return splitStr.join(' ');
-  })
-  return return_array
+  });
+  return return_array;
 }
 
+function hex(n) {
+  const validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
+  let array = new Uint8Array(n || 87);
+  window.crypto.getRandomValues(array);
+  array = array.map((x) => validChars.charCodeAt(x % validChars.length));
+  const randomState = String.fromCharCode.apply(null, array);
+  return randomState;
+}
 
-
-export default ServiceForm
+export default ServiceForm;

--- a/federation-registry-frontend/src/form_field_config.json
+++ b/federation-registry-frontend/src/form_field_config.json
@@ -1,0 +1,88 @@
+{
+  "version": "1.0",
+  "description": "Configuration for ServiceForm field ordering and visibility.",
+  "tabs": [
+    {
+      "key": "general",
+      "titleKey": "form_tab_general",
+      "order": 1,
+      "visibleIf": null
+    },
+    {
+      "key": "protocol",
+      "titleKey": "form_tab_protocol",
+      "order": 2,
+      "visibleIf": null
+    }
+  ],
+  "fields_by_tab": {
+    "general": [
+      "service_name",
+      "integration_environment",
+      "logo_uri",
+      "website_url",
+      "service_description",
+      "country",
+      "policy_uri",
+      "contacts"
+    ],
+    "protocol": [
+      "application_type",
+      "grant_types",
+      "token_endpoint_auth_method",
+      "client_secret",
+      "token_endpoint_auth_signing_alg",
+      "jwks",
+      "jwks_uri",
+      "allow_introspection",
+      "scope",
+      "redirect_uris",
+      "post_logout_redirect_uris",
+      "code_challenge_method",
+      "refresh_token_validity_seconds",
+      "device_code_validity_seconds",
+      "access_token_validation_model",
+      "access_token_validity_seconds",
+      "id_token_timeout_seconds",
+      "entity_id",
+      "metadata_url",
+      "requested_attributes"
+    ]
+  },
+  "field_order": {
+    "general": [
+      { "field": "service_name", "order": 1, "required": true },
+      { "field": "integration_environment", "order": 2, "required": true },
+      { "field": "logo_uri", "order": 3, "required": false },
+      { "field": "website_url", "order": 4, "required": false },
+      { "field": "service_description", "order": 5, "required": true },
+      { "field": "country", "order": 6, "required": false },
+      { "field": "policy_uri", "order": 7, "required": false },
+      { "field": "contacts", "order": 8, "required": true }
+    ],
+    "protocol_oidc": [
+      { "field": "application_type", "order": 1, "required": true },
+      { "field": "grant_types", "order": 2, "required": false },
+      { "field": "token_endpoint_auth_method", "order": 3, "required": true },
+      { "field": "client_secret", "order": 4, "required": false },
+      { "field": "token_endpoint_auth_signing_alg", "order": 5, "required": false },
+      { "field": "jwks", "order": 6, "required": false },
+      { "field": "jwks_uri", "order": 7, "required": false },
+      { "field": "allow_introspection", "order": 8, "required": false },
+      { "field": "scope", "order": 9, "required": false },
+      { "field": "redirect_uris", "order": 10, "required": false },
+      { "field": "post_logout_redirect_uris", "order": 11, "required": false },
+      { "field": "code_challenge_method", "order": 12, "required": true },
+      { "field": "refresh_token_validity_seconds", "order": 13, "required": false },
+      { "field": "device_code_validity_seconds", "order": 14, "required": false },
+      { "field": "access_token_validation_model", "order": 15, "required": true },
+      { "field": "access_token_validity_seconds", "order": 16, "required": true },
+      { "field": "id_token_timeout_seconds", "order": 17, "required": true }
+    ],
+    "protocol_saml": [
+      { "field": "entity_id", "order": 1, "required": true },
+      { "field": "metadata_url", "order": 2, "required": true },
+      { "field": "requested_attributes", "order": 3, "required": false }
+    ]
+  }
+}


### PR DESCRIPTION
# Goal
To make the order of all form items in service config customizable. [form_field_config.json](https://github.com/rciam/rciam-federation-registry/compare/devel...JiriProkop:rciam-federation-registry:prokop/service_form?expand=1#diff-1b90e3515521623f6417c5e0b706138f175be7356d72963dfe3c73c7b9237706)  is entirely optional, the form should default to the previous order.

Since the file was so long, refactor was also done.

# Additional notes
I'm not gonna lie, all of this was done by an agent. If you have any better idea on how to achieve/implement this, so this can be merged, I'm open to it. This is basicaly a draft.
